### PR TITLE
fix: vite example add missing imports and general improvements

### DIFF
--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -20,11 +20,13 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "file:../../node_modules/convex",
+    "convex-helpers": "file:../../node_modules/convex-helpers",
     "lucide-react": "^0.486.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sonner": "^2.0.2",
     "tailwind-merge": "^3.1.0",
+    "tailwindcss": "^4.1.7",
     "tw-animate-css": "^1.2.5"
   },
   "devDependencies": {

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -6,13 +6,16 @@ import { useConvexAuth } from "convex/react";
 
 export default function App() {
   const [showSignIn, setShowSignIn] = useState(true);
-  const { isAuthenticated, isLoading } = useConvexAuth();
-  console.log("isAuthenticated", isAuthenticated);
-  console.log("isLoading", isLoading);
-  if (isLoading) {
+  const authState = useConvexAuth();
+
+  useEffect(() => {
+    console.log("Auth state changed:", authState);
+  }, [authState]);
+
+  if (authState.isLoading) {
     return <div>Loading...</div>;
   }
-  if (isAuthenticated) {
+  if (authState.isAuthenticated) {
     return <Dashboard />;
   }
 


### PR DESCRIPTION
This PR tries to generally improve the vite example by
- Adding two missing imports `tailwindcss` & `convex-helpers`
- Some minor code improvements in `App.tsx`