### PR TITLE
Fixed missing export in convex/auth.ts example

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1031,7 +1031,8 @@ export default function Home() {
 
                   const http = httpRouter()
 
-                  betterAuthComponent.registerRoutes(http, createAuth)
+                  // { cors: true } is required for client side frameworks
+                  betterAuthComponent.registerRoutes(http, createAuth, { cors: true })
 
                   export default http
                 `,

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -665,6 +665,7 @@ export default function Home() {
                     BetterAuth,
                     convexAdapter,
                     type AuthFunctions,
+                    type PublicAuthFunctions,
                   } from "@convex-dev/better-auth";
                   import { convex, crossDomain } from "@convex-dev/better-auth/plugins";
                   import { requireEnv } from "@convex-dev/better-auth/utils";
@@ -678,12 +679,14 @@ export default function Home() {
 
                   // Typesafe way to pass Convex functions defined in this file
                   const authFunctions: AuthFunctions = internal.auth;
+                  const publicAuthFunctions: PublicAuthFunctions = api.auth;
 
                   // Initialize the component
                   export const betterAuthComponent = new BetterAuth(
                     components.betterAuth,
                     {
                       authFunctions,
+                      publicAuthFunctions,
                     }
                   );
 
@@ -849,21 +852,24 @@ export default function Home() {
                     BetterAuth,
                     convexAdapter,
                     type AuthFunctions,
+                    type PublicAuthFunctions,
                   } from "@convex-dev/better-auth";
                   import { convex } from "@convex-dev/better-auth/plugins";
                   import { betterAuth } from "better-auth";
-                  import { components, internal } from "./_generated/api";
+                  import { api, components, internal } from "./_generated/api";
                   import { query, type GenericCtx } from "./_generated/server";
                   import type { Id, DataModel } from "./_generated/dataModel";
 
                   // Typesafe way to pass Convex functions defined in this file
                   const authFunctions: AuthFunctions = internal.auth;
+                  const publicAuthFunctions: PublicAuthFunctions = api.auth;
 
                   // Initialize the component
                   export const betterAuthComponent = new BetterAuth(
                     components.betterAuth,
                     {
                       authFunctions,
+                      publicAuthFunctions,
                     }
                   );
 

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -708,6 +708,26 @@ export default function Home() {
                       ],
                     });
 
+                  // These are required named exports
+                  export const {
+                    createUser,
+                    updateUser,
+                    deleteUser,
+                    createSession,
+                    isAuthenticated,
+                  } =
+                    betterAuthComponent.createAuthFunctions<DataModel>({
+                      // Must create a user and return the user id
+                      onCreateUser: async (ctx, user) => {
+                        return ctx.db.insert("users", {});
+                      },
+
+                      // Delete the user when they are deleted from Better Auth
+                      onDeleteUser: async (ctx, userId) => {
+                        await ctx.db.delete(userId as Id<"users">);
+                      },
+                    });
+
                   // Example function for getting the current user
                   // Feel free to edit, omit, etc.
                   export const getCurrentUser = query({
@@ -871,6 +891,7 @@ export default function Home() {
                     updateUser,
                     deleteUser,
                     createSession,
+                    isAuthenticated,
                   } =
                     betterAuthComponent.createAuthFunctions<DataModel>({
                       // Must create a user and return the user id

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -665,7 +665,6 @@ export default function Home() {
                     BetterAuth,
                     convexAdapter,
                     type AuthFunctions,
-                    type PublicAuthFunctions,
                   } from "@convex-dev/better-auth";
                   import { convex, crossDomain } from "@convex-dev/better-auth/plugins";
                   import { requireEnv } from "@convex-dev/better-auth/utils";
@@ -679,14 +678,12 @@ export default function Home() {
 
                   // Typesafe way to pass Convex functions defined in this file
                   const authFunctions: AuthFunctions = internal.auth;
-                  const publicAuthFunctions: PublicAuthFunctions = api.auth;
 
                   // Initialize the component
                   export const betterAuthComponent = new BetterAuth(
                     components.betterAuth,
                     {
                       authFunctions,
-                      publicAuthFunctions,
                     }
                   );
 
@@ -717,7 +714,6 @@ export default function Home() {
                     updateUser,
                     deleteUser,
                     createSession,
-                    isAuthenticated,
                   } =
                     betterAuthComponent.createAuthFunctions<DataModel>({
                       // Must create a user and return the user id
@@ -852,7 +848,6 @@ export default function Home() {
                     BetterAuth,
                     convexAdapter,
                     type AuthFunctions,
-                    type PublicAuthFunctions,
                   } from "@convex-dev/better-auth";
                   import { convex } from "@convex-dev/better-auth/plugins";
                   import { betterAuth } from "better-auth";
@@ -862,14 +857,12 @@ export default function Home() {
 
                   // Typesafe way to pass Convex functions defined in this file
                   const authFunctions: AuthFunctions = internal.auth;
-                  const publicAuthFunctions: PublicAuthFunctions = api.auth;
 
                   // Initialize the component
                   export const betterAuthComponent = new BetterAuth(
                     components.betterAuth,
                     {
                       authFunctions,
-                      publicAuthFunctions,
                     }
                   );
 
@@ -897,7 +890,6 @@ export default function Home() {
                     updateUser,
                     deleteUser,
                     createSession,
-                    isAuthenticated,
                   } =
                     betterAuthComponent.createAuthFunctions<DataModel>({
                       // Must create a user and return the user id


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixed the react example for convex/auth.ts which was causing a type error because of a missing export.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
