### PR TITLE
Fix incorrect reference to auth-client version of reactStartHandler

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1233,7 +1233,7 @@ export default function Home() {
                     language: "typescript",
                     filename: "src/routes/api/auth/$.ts",
                     code: stripIndent`
-                      import { reactStartHandler } from '@/lib/auth-client'
+                      import { reactStartHandler } from '@/lib/server-auth-utils'
 
                       export const ServerRoute = createServerFileRoute().methods({
                         GET: ({ request }) => {

--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1234,8 +1234,9 @@ export default function Home() {
                     filename: "src/routes/api/auth/$.ts",
                     code: stripIndent`
                       import { reactStartHandler } from '@/lib/server-auth-utils'
+                      import { createServerFileRoute } from '@tanstack/react-start/server'
 
-                      export const ServerRoute = createServerFileRoute().methods({
+                      export const ServerRoute = createServerFileRoute('/api/auth/$').methods({
                         GET: ({ request }) => {
                           return reactStartHandler(request)
                         },


### PR DESCRIPTION
<!-- Describe your PR here. -->

In src/routes/api/auth/$.ts is looks like reactStartHandler should be imported from the server-side utility file, rather than client-auth.ts

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
