### PR TITLE
docs: add local convex url to ENVs examples

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -636,9 +636,13 @@ export default function Home() {
                   CONVEX_DEPLOYMENT=dev:adjective-animal-123 # team: team-name, project: project-name
 
                   VITE_CONVEX_URL=https://adjective-animal-123.convex.cloud
+                  # Or if you are using the local convex instance
+                  # VITE_CONVEX_URL=http://127.0.0.1:3210
                   
                   # Same as VITE_CONVEX_URL but ends in .site
                   VITE_CONVEX_SITE_URL=https://adjective-animal-123.convex.site
+                  # Or if you are using the local convex instance
+                  # VITE_CONVEX_SITE_URL=http://127.0.0.1:3211
                 `,
               },
               {
@@ -652,9 +656,13 @@ export default function Home() {
                   CONVEX_DEPLOYMENT=dev:adjective-animal-123 # team: team-name, project: project-name
 
                   NEXT_PUBLIC_CONVEX_URL=https://adjective-animal-123.convex.cloud
+                  # Or if you are using the local convex instance
+                  # NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
                   
                   # Same as NEXT_PUBLIC_CONVEX_URL but ends in .site
                   NEXT_PUBLIC_CONVEX_SITE_URL=https://adjective-animal-123.convex.site
+                  # Or if you are using the local convex instance
+                  # NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3211
                 `,
               },
               {
@@ -668,9 +676,13 @@ export default function Home() {
                   CONVEX_DEPLOYMENT=dev:adjective-animal-123 # team: team-name, project: project-name
 
                   VITE_CONVEX_URL=https://adjective-animal-123.convex.cloud
+                  # Or if you are using the local convex instance
+                  # VITE_CONVEX_URL=http://127.0.0.1:3210
                   
                   # Same as VITE_CONVEX_URL but ends in .site
                   VITE_CONVEX_SITE_URL=https://adjective-animal-123.convex.site
+                  # Or if you are using the local convex instance
+                  # VITE_CONVEX_SITE_URL=http://127.0.0.1:3211
                 `,
               },
             ]}


### PR DESCRIPTION
<!-- Describe your PR here. -->
I was setting this up using local convex instance, and I could not find any information on what was the local convex URL for `VITE_CONVEX_SITE_URL`, and since I don't know convex that well, I did not know where to find the information.

I may not be the first one and I surely won't be the last searching for this, so just adding it there if its ok with you for the next person.

The change essentially adds:
```env
VITE_CONVEX_URL=http://127.0.0.1:3210
VITE_CONVEX_SITE_URL=http://127.0.0.1:3211
```

With informational comments on why its here (also changed the `NEXT_PUBLIC` ones)

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
