### PR TITLE
fix: updated type exports for client plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
         "default": "./dist/esm/client/plugins/index.js"
       },
       "require": {
-        "types": "./dist/commonjs/plugins/clientPlugins.d.ts",
-        "default": "./dist/commonjs/plugins/clientPlugins.js"
+        "types": "./dist/commonjs/client/plugins/index.d.ts",
+        "default": "./dist/commonjs/client/plugins/index.js"
       }
     },
     "./nextjs": {


### PR DESCRIPTION
<!-- Describe your PR here. -->
**Problem:**
TypeScript was throwing the following error when attempting to import from `@convex-dev/better-auth/client/plugins` and other client plugin types:
`Cannot find module '@convex-dev/better-auth/client/plugins' or its corresponding type declarations.ts`

**Root Cause:**
The exports field in package.json referenced invalid build files:
```json
"require": {
  "types": "./dist/commonjs/plugins/clientPlugins.d.ts", 
  "default": "./dist/commonjs/plugins/clientPlugins.js"  
}
```
These files `(clientPlugins.d.ts and .js)` were not present. The actual build output was located at `./dist/commonjs/client/plugins/index.*.`

**Solution:**
Updated the exports to point to the correct paths:
```json
"require": {
  "types": "./dist/commonjs/client/plugins/index.d.ts", 
  "default": "./dist/commonjs/client/plugins/index.js"   
}
```

With this change, TypeScript can now correctly resolve the module, and the following import works in both ESM and CommonJS environments:


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
