### PR TITLE
fix(types): added convex.config types for commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,10 @@
       "import": {
         "types": "./dist/esm/component/convex.config.d.ts",
         "default": "./dist/esm/component/convex.config.js"
+      },
+      "require": {
+        "types": "./dist/commonjs/component/convex.config.d.ts",
+        "default": "./dist/commonjs/component/convex.config.js"
       }
     }
   },


### PR DESCRIPTION
<!-- Describe your PR here. -->
**Problem:**
TypeScript was throwing the following error when attempting to import from `@convex-dev/better-auth/convex.config`:
`Cannot find module '@convex-dev/better-auth/convex.config' or its corresponding type declarations.ts`

**Root Cause:**
The exports field in package.json was missing the `convex.config` export path for commonjs.

**Solution:**
Updated the exports to point to the correct paths:
```json
"require": {
  "types": "./dist/commonjs/component/convex.config.d.ts", 
  "default": "./dist/commonjs/component/convex.config.js"   
}
```

With this change, TypeScript can now correctly resolve the module, and the following import works in both ESM and CommonJS environments:
```typescript
import betterAuth from "@convex-dev/better-auth/convex.config";
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.