### PR TITLE
fix: resolve stale closure bug in fetchToken callback

### DIFF
--- a/src/react/client.tsx
+++ b/src/react/client.tsx
@@ -110,7 +110,7 @@ export function AuthProvider({
     };
 
     return fetchWithRetry();
-  }, [client]);
+  }, [authClient, logVerbose]);
 
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {


### PR DESCRIPTION
The fetchToken callback in ConvexBetterAuthProvider had incorrect dependencies, causing it to capture stale authClient references. This prevented Convex JWT token fetching from working correctly when authClient prop changed or plugins were dynamically loaded.

- Updated dependency array from [client] to [authClient, logVerbose]
- Ensures callback updates when authClient changes (fixing dynamic plugin loading)
- Fixes silent authentication failures in mobile/native apps using Better Auth with Convex

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
