### PR TITLE
fix: update jwks_uri to include options basePath

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -45,7 +45,7 @@ export const convex = <O extends BetterAuthOptions>(
     loginPage: "/not-used",
     metadata: {
       issuer: `${process.env.CONVEX_SITE_URL}`,
-      jwks_uri: `${process.env.CONVEX_SITE_URL}/api/auth/convex/jwks`,
+      jwks_uri: `${process.env.CONVEX_SITE_URL}${opts.options?.basePath ?? "/api/auth"}/convex/jwks`,
     },
   });
   const jwt = jwtPlugin({


### PR DESCRIPTION
<!-- Describe your PR here. -->
This fixes the JWKS URI in the Convex plugin, so it is no longer hardcoded. Previously, when users set a `basePath `other than `/api/auth` in `createAuth`, the HTTP action was set correctly, but the JWKS URI in the OIDC provider was not, which resulted in a mismatch. Now, it uses the base URL from the Better Auth Options.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
