### PR TITLE
Fix tanstack documentation import statement

### DIFF
--- a/docs/app/page.tsx
+++ b/docs/app/page.tsx
@@ -1355,8 +1355,8 @@ const Home = () => {
                       import { ConvexReactClient } from 'convex/react'
                       import { getCookie, getWebRequest } from '@tanstack/react-start/server'
                       import { ConvexBetterAuthProvider } from '@convex-dev/better-auth/react'
+                      import { authClient } from "@/lib/auth-client";
                       import {
-                        authClient,
                         fetchSession,
                         getCookieName,
                       } from '@/lib/server-auth-utils'


### PR DESCRIPTION
It's correct in examples/tanstack, but not in the docs:

https://github.com/get-convex/better-auth/blob/799f11d131bf8f77164a8aef60870a03ff00d5e5/examples/tanstack/src/routes/__root.tsx#L12-L13

<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
