### PR TITLE
Accept UserId type parameter in convexAdapter

### DIFF
--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -99,9 +99,9 @@ interface ConvexAdapterConfig {
    */
   debugLogs?: AdapterDebugLogs;
 }
-export const convexAdapter = (
+export const convexAdapter = <UserId extends string = string>(
   ctx: GenericCtx,
-  component: BetterAuth,
+  component: BetterAuth<UserId>,
   config: ConvexAdapterConfig = {}
 ) => {
   const { debugLogs } = config;


### PR DESCRIPTION
BetterAuth class accepts a type parameter UserId. However if used, it causes a type error when passing it to convexAdapter because this function only accepts BetterAuth<string>

This change fixes code such as the following:

```ts
export const betterAuthComponent = new BetterAuth<Id<"users">>(components.betterAuth, {
  authFunctions,
  publicAuthFunctions,
});

// ...

betterAuth({
    database: convexAdapter(ctx, betterAuthComponent),
    ...
})
```

Before this would give the type error

```
Argument of type 'BetterAuth<Id<"users">>' is not assignable to parameter of type 'BetterAuth<string>'.
  Types of property 'createAuthFunctions' are incompatible.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
