### PR TITLE
userId can't be optional

### DIFF
--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -24,7 +24,7 @@ const schema = defineSchema({
     banReason: v.optional(v.union(v.null(), v.string())),
     banExpires: v.optional(v.union(v.null(), v.number())),
     stripeCustomerId: v.optional(v.union(v.null(), v.string())),
-    userId: v.optional(v.union(v.null(), v.string())),
+    userId: v.string(),
     teamId: v.optional(v.union(v.null(), v.string())),
   })
     .index("email_name", ["email","name"])


### PR DESCRIPTION
<!-- Describe your PR here. -->
`onCreateUser` handler is required to return an id that is used to create this record: https://github.com/get-convex/better-auth/blob/49bf0199bd5cebdd11b2f249d4fe4dba7c7c7f24/src/client/index.ts#L252

This removes the need to do a null check everytime.


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
