### PR TITLE
Add trustedOrigins to Tanstack example

### DIFF
--- a/examples/tanstack/src/lib/auth.ts
+++ b/examples/tanstack/src/lib/auth.ts
@@ -16,6 +16,7 @@ const siteUrl = requireEnv('SITE_URL')
 
 export const createAuth = (ctx: GenericCtx) =>
   betterAuth({
+    trustedOrigins: ["http://localhost:3000"],
     baseURL: siteUrl,
     database: convexAdapter(ctx, betterAuthComponent),
     account: {


### PR DESCRIPTION
This just adds 
trustedOrigins: ["http://localhost:3000"]
to the Tanstack betterAuth configuration



----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
