### PR TITLE
Fix/Clean up TanStack Example

### DIFF
--- a/examples/tanstack/src/components/TodoListServer.tsx
+++ b/examples/tanstack/src/components/TodoListServer.tsx
@@ -14,13 +14,7 @@ import { createServerFn } from '@tanstack/react-start'
 import { convexQuery } from '@convex-dev/react-query'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { ConvexHttpClient } from 'convex/browser'
-import { getCookie } from '@tanstack/react-start/server'
-import { getCookieName } from '@/lib/auth-server-utils'
-
-const getToken = async () => {
-  const sessionCookieName = await getCookieName()
-  return getCookie(sessionCookieName)
-}
+import { getRequestToken } from '@/lib/auth-server-utils'
 
 function setupClient(token?: string) {
   const client = new ConvexHttpClient(import.meta.env.VITE_CONVEX_URL)
@@ -45,7 +39,7 @@ export const toggleCompletedTodo = createServerFn({ method: 'POST' })
     }
   })
   .handler(async ({ data: { id } }) => {
-    const token = await getToken()
+    const token = await getRequestToken()
     await setupClient(token).mutation(api.todos.toggle, {
       id: id as Id<'todos'>,
     })
@@ -59,7 +53,7 @@ export const removeTodo = createServerFn({ method: 'POST' })
     return data
   })
   .handler(async ({ data: { id } }) => {
-    const token = await getToken()
+    const token = await getRequestToken()
     await setupClient(token).mutation(api.todos.remove, {
       id: id as Id<'todos'>,
     })
@@ -79,7 +73,7 @@ export const addTodo = createServerFn({ method: 'POST' })
     }
   })
   .handler(async ({ data: { text } }) => {
-    const token = await getToken()
+    const token = await getRequestToken()
     await setupClient(token).mutation(api.todos.create, { text })
   })
 
@@ -93,7 +87,7 @@ export const TodoList = () => {
           event.preventDefault()
           const formData = new FormData(event.currentTarget)
           await addTodo({ data: formData })
-          ;(event.target as HTMLFormElement).reset()
+            ; (event.target as HTMLFormElement).reset()
         }}
       />
 

--- a/examples/tanstack/src/lib/auth-server-utils.ts
+++ b/examples/tanstack/src/lib/auth-server-utils.ts
@@ -1,7 +1,19 @@
 import { createAuth } from '@/lib/auth'
 import { reactStartHelpers } from '@convex-dev/better-auth/react-start'
+import { getWebRequest } from '@tanstack/react-start/server'
 
 export const { fetchSession, reactStartHandler, getCookieName } =
   reactStartHelpers(createAuth, {
     convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL,
   })
+
+export const getRequestToken = async () => {
+  const request = getWebRequest()
+  const sessionCookieName = await getCookieName()
+  const cookieHeader = request.headers.get('cookie') || ''
+  const token = cookieHeader
+    .split('; ')
+    .find((c) => c.startsWith(`__Secure-${sessionCookieName}=`))
+    ?.split('=')[1]
+  return token
+}

--- a/examples/tanstack/src/lib/auth.ts
+++ b/examples/tanstack/src/lib/auth.ts
@@ -16,6 +16,7 @@ const siteUrl = requireEnv('SITE_URL')
 
 export const createAuth = (ctx: GenericCtx) =>
   betterAuth({
+    trustedOrigins: ["http://localhost:3000"],
     baseURL: siteUrl,
     database: convexAdapter(ctx, betterAuthComponent),
     account: {

--- a/examples/tanstack/src/router.tsx
+++ b/examples/tanstack/src/router.tsx
@@ -20,7 +20,6 @@ export function createRouter() {
   }
   const convex = new ConvexReactClient(CONVEX_URL, {
     unsavedChangesWarning: false,
-    // expectAuth: true
   })
   const convexQueryClient = new ConvexQueryClient(convex)
 

--- a/examples/tanstack/src/router.tsx
+++ b/examples/tanstack/src/router.tsx
@@ -7,6 +7,12 @@ import { ConvexProvider, ConvexReactClient } from 'convex/react'
 import { ConvexQueryClient } from '@convex-dev/react-query'
 import { QueryClient } from '@tanstack/react-query'
 
+export interface RouterContext {
+  queryClient: QueryClient
+  convexClient: ConvexReactClient
+  convexQueryClient: ConvexQueryClient
+}
+
 export function createRouter() {
   const CONVEX_URL = (import.meta as any).env.VITE_CONVEX_URL!
   if (!CONVEX_URL) {
@@ -14,6 +20,7 @@ export function createRouter() {
   }
   const convex = new ConvexReactClient(CONVEX_URL, {
     unsavedChangesWarning: false,
+    // expectAuth: true
   })
   const convexQueryClient = new ConvexQueryClient(convex)
 

--- a/examples/tanstack/src/routes/__root.tsx
+++ b/examples/tanstack/src/routes/__root.tsx
@@ -2,9 +2,11 @@ import {
   Outlet,
   createRootRouteWithContext,
   useRouteContext,
+  HeadContent,
+  Scripts,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
-import { Meta, Scripts, createServerFn } from '@tanstack/react-start'
+import { createServerFn } from '@tanstack/react-start'
 import { QueryClient } from '@tanstack/react-query'
 import * as React from 'react'
 import appCss from '@/styles/app.css?url'
@@ -83,7 +85,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="dark">
       <head>
-        <Meta />
+        <HeadContent />
       </head>
       <body className="bg-neutral-950 text-neutral-50">
         {children}

--- a/examples/tanstack/src/routes/_authed/client-only.index.tsx
+++ b/examples/tanstack/src/routes/_authed/client-only.index.tsx
@@ -1,10 +1,15 @@
 import { TodoList } from '@/components/TodoListClient'
 import { createFileRoute } from '@tanstack/react-router'
+import { Authenticated } from 'convex/react'
 
 export const Route = createFileRoute('/_authed/client-only/')({
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  return <TodoList />
+  return (
+    <Authenticated>
+      <TodoList />
+    </Authenticated>
+  )
 }

--- a/examples/tanstack/src/routes/_authed/server.tsx
+++ b/examples/tanstack/src/routes/_authed/server.tsx
@@ -15,6 +15,7 @@ import { convexQuery } from '@convex-dev/react-query'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { authClient } from '@/lib/auth-client'
 import { useTransition } from 'react'
+import { Authenticated } from 'convex/react'
 
 export const Route = createFileRoute('/_authed/server')({
   component: ServerComponent,
@@ -36,7 +37,9 @@ function ServerComponent() {
         isPending={isPending}
       />
       <Header />
-      <TodoList />
+      <Authenticated>
+        <TodoList />
+      </Authenticated>
       <Toaster />
     </AppContainer>
   )


### PR DESCRIPTION
This PR aims to clean up a few issues with the TanStack example?

1. Loading on hard reload
 a. client side: wrap with `<Authenticated>`
 b. server side: wrap with `<Authenticated>` **and** update how ServerFns get tokens. The ServerFns need to get their tokens from the request. 
2. Add the default dev url to the TrustedOrigins. BetterAuth api calls fail without this.
3. Small Quality of Life improvements:
 a. define RouterContext to fix type error
 b. updated imports for Meta and Scripts


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
