### PR TITLE
docs: Fix Supported Plugins Doc Page's Broken URL for Two Factor

### DIFF
--- a/docs/content/docs/supported-plugins.mdx
+++ b/docs/content/docs/supported-plugins.mdx
@@ -20,5 +20,5 @@ Install](/local-install).
 - [One Tap](https://www.better-auth.com/docs/plugins/one-tap)
 - [Passkey](https://www.better-auth.com/docs/plugins/passkey)
 - [Phone Number](https://www.better-auth.com/docs/plugins/phone-number)
-- [Two Factor](https://www.better-auth.com/docs/plugins/two-factor)
+- [Two Factor](https://www.better-auth.com/docs/plugins/2fa)
 - [Username](https://www.better-auth.com/docs/plugins/username)


### PR DESCRIPTION
In the Supported Plugins doc page, the URL that linked to Better Auth's Two Factor doc page was broken. Now it is fixed with this PR.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
