### PR TITLE
Fix incorrect reference to "nextjs"

### DIFF
--- a/docs/content/docs/framework-guides/next.mdx
+++ b/docs/content/docs/framework-guides/next.mdx
@@ -200,7 +200,7 @@ description: Install and configure Convex + Better Auth for Next.js.
     Set up route handlers to proxy auth requests from your framework server to your Convex deployment.
 
     ```ts title="app/api/auth/[...all]/route.ts"
-    import { nextJsHandler } from "@convex-dev/better-auth/nextjs";
+    import { nextJsHandler } from "@convex-dev/better-auth/next-js";
 
     export const { GET, POST } = nextJsHandler();
     ```
@@ -254,7 +254,7 @@ First, a token helper for calling Convex functions from your server code.
 
 ```ts title="src/lib/auth-server.ts"
 import { createAuth } from "convex/auth";
-import { getToken as getTokenNextjs } from "@convex-dev/better-auth/nextjs";
+import { getToken as getTokenNextjs } from "@convex-dev/better-auth/next-js";
 
 export const getToken = () => {
   return getTokenNextjs(createAuth);


### PR DESCRIPTION
The docs specify the imports are to "@convex-dev/better-auth/nextjs" whilst the correct path is "@convex-dev/better-auth/next-js". For consistency maybe renaming the path to "nextjs", as other packages ("convex/nextjs") use "nextjs" instead of "next-js"

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
