### PR TITLE
docs: fix typos in framework guide for sveltekit

### DIFF
--- a/docs/content/docs/framework-guides/sveltekit.mdx
+++ b/docs/content/docs/framework-guides/sveltekit.mdx
@@ -326,7 +326,7 @@ Note: To add SSR support (`data.currentUser`) also add the `src/routes/+page.ser
 	import { authClient } from '$lib/auth-client.js';
 	import { api } from '$convex/_generated/api.js';
 	import { useQuery } from 'convex-svelte';
-	import { useAuth } from '$lib/svelte/index.js';
+	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 
 	let { data } = $props();
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Changes:
- Change `src/lib/convex/auth.ts` docs path to `src/convex/auth.ts`
- Change `src/lib/convex/http.ts` docs path to `src/convex/http.ts`
- Change `SITE_URL` value to SvelteKit's default `http://localhost:5173`


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
