### PR TITLE
Remove debug log for ctx.path

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -96,7 +96,6 @@ export const convex = (
         ...oidcProvider.hooks.after,
         {
           matcher: (ctx) => {
-            console.log("ctx.path", ctx.path);
             return (
               ctx.path.startsWith("/sign-in") ||
               ctx.path.startsWith("/sign-up") ||


### PR DESCRIPTION
Remove console log statement for context path.

EDIT: I'm sorry for the silly PR, but I'm sure I wasn't the only one bothered by the million logs.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
