### PR TITLE
♻️ refactor: update better-auth type imports to use new naming

### DIFF
--- a/src/client/adapterUtils.ts
+++ b/src/client/adapterUtils.ts
@@ -12,7 +12,7 @@ import {
 import { stream } from "convex-helpers/server/stream";
 import { mergedStream } from "convex-helpers/server/stream";
 import { stripIndent } from "common-tags";
-import { BetterAuthDbSchema } from "better-auth/db";
+import { BetterAuthDBSchema } from "better-auth/db";
 
 export const adapterWhereValidator = v.object({
   field: v.string(),
@@ -57,7 +57,7 @@ export const adapterArgsValidator = v.object({
 });
 
 const isUniqueField = (
-  betterAuthSchema: BetterAuthDbSchema,
+  betterAuthSchema: BetterAuthDBSchema,
   model: string,
   field: string
 ) => {
@@ -72,7 +72,7 @@ const isUniqueField = (
     .includes(field);
 };
 export const hasUniqueFields = (
-  betterAuthSchema: BetterAuthDbSchema,
+  betterAuthSchema: BetterAuthDBSchema,
   model: string,
   input: Record<string, any>
 ) => {
@@ -241,7 +241,7 @@ export const checkUniqueFields = async <
 >(
   ctx: GenericQueryCtx<GenericDataModel>,
   schema: Schema,
-  betterAuthSchema: BetterAuthDbSchema,
+  betterAuthSchema: BetterAuthDBSchema,
   table: string,
   input: Record<string, any>,
   doc?: Record<string, any>
@@ -466,7 +466,7 @@ export const paginate = async <
 >(
   ctx: GenericQueryCtx<GenericDataModel>,
   schema: SchemaDefinition<any, any>,
-  betterAuthSchema: BetterAuthDbSchema,
+  betterAuthSchema: BetterAuthDBSchema,
   args: Infer<typeof adapterArgsValidator> & {
     paginationOpts: PaginationOptions;
   }
@@ -623,7 +623,7 @@ export const listOne = async <
 >(
   ctx: GenericQueryCtx<GenericDataModel>,
   schema: SchemaDefinition<any, any>,
-  betterAuthSchema: BetterAuthDbSchema,
+  betterAuthSchema: BetterAuthDBSchema,
   args: Infer<typeof adapterArgsValidator>
 ): Promise<Doc | null> => {
   return (

--- a/src/client/createSchema.ts
+++ b/src/client/createSchema.ts
@@ -1,4 +1,4 @@
-import { BetterAuthDbSchema, type FieldAttribute } from "better-auth/db";
+import { BetterAuthDBSchema, type DBFieldAttribute } from "better-auth/db";
 
 // Manually add fields to index on for schema generation,
 // all fields in the schema specialFields are automatically indexed
@@ -13,7 +13,7 @@ export const indexFields = {
 };
 
 // Return map of unique, sortable, and reference fields
-const specialFields = (tables: BetterAuthDbSchema) =>
+const specialFields = (tables: BetterAuthDBSchema) =>
   Object.fromEntries(
     Object.entries(tables)
       .map(([key, table]) => {
@@ -38,7 +38,7 @@ const specialFields = (tables: BetterAuthDbSchema) =>
       )
   );
 
-const mergedIndexFields = (tables: BetterAuthDbSchema) =>
+const mergedIndexFields = (tables: BetterAuthDBSchema) =>
   Object.fromEntries(
     Object.entries(tables).map(([key]) => {
       const manualIndexes = indexFields[key as keyof typeof indexFields] || [];
@@ -59,7 +59,7 @@ export const createSchema = async ({
   file,
   tables,
 }: {
-  tables: BetterAuthDbSchema;
+  tables: BetterAuthDBSchema;
   file?: string;
 }) => {
   // stop convex esbuild from throwing over this import, only runs
@@ -94,7 +94,7 @@ export const tables = {
       Object.entries(table.fields).filter(([key]) => key !== "id")
     );
 
-    function getType(name: string, field: FieldAttribute) {
+    function getType(name: string, field: DBFieldAttribute) {
       const type = field.type as
         | "string"
         | "number"
@@ -126,7 +126,7 @@ export const tables = {
 ${Object.keys(fields)
   .map((field) => {
     const attr = fields[field]!;
-    const type = getType(field, attr as FieldAttribute);
+    const type = getType(field, attr as DBFieldAttribute);
     const optional = (fieldSchema: string) =>
       attr.required
         ? fieldSchema


### PR DESCRIPTION
Update type imports from better-auth/db to match upstream changes:
- BetterAuthDbSchema → BetterAuthDBSchema
- FieldAttribute → DBFieldAttribute

The old types are deprecated and will be removed on better auth 1.4.x.