### PR TITLE
Swap oldDoc/newDoc in onUpdate trigger type definition

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -417,11 +417,11 @@ export type Triggers<
     ) => Promise<void>;
     onUpdate?: <Ctx extends GenericMutationCtx<DataModel>>(
       ctx: Ctx,
-      oldDoc: Infer<Schema["tables"][K]["validator"]> & {
+      newDoc: Infer<Schema["tables"][K]["validator"]> & {
         _id: string;
         _creationTime: number;
       },
-      newDoc: Infer<Schema["tables"][K]["validator"]> & {
+      oldDoc: Infer<Schema["tables"][K]["validator"]> & {
         _id: string;
         _creationTime: number;
       }


### PR DESCRIPTION
This mirrors the breaking change in 0.9. When I used "jump to definition" on `onUpdate` field to check if I'm on an affected version, I was confused as the argument order of this trigger type definition didn't match the docs.


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
