### PR TITLE
Add `crossDomain` plugin to the list of imports

### DIFF
--- a/docs/content/docs/framework-guides/expo.mdx
+++ b/docs/content/docs/framework-guides/expo.mdx
@@ -300,7 +300,10 @@ Add the site URL and the cross-domain plugin to the Better Auth instance.
 
 ```ts title="convex/auth.ts"
 import { createClient, type GenericCtx } from "@convex-dev/better-auth";
-import { convex } from "@convex-dev/better-auth/plugins";
+import { 
+  convex,
+  crossDomain // [!code ++]
+} from "@convex-dev/better-auth/plugins";
 import { betterAuth } from "better-auth";
 import { expo } from "@better-auth/expo";
 import { components } from "./_generated/api";


### PR DESCRIPTION
This pull request introduces a small update to the Expo framework guide documentation. The change adds the `crossDomain` plugin to the list of imports from `@convex-dev/better-auth/plugins`, preparing the guide for cross-domain authentication use cases.

* Documentation update:
  * Added `crossDomain` to the import statement in `docs/content/docs/framework-guides/expo.mdx` to support cross-domain authentication scenarios.