### PR TITLE
Fix undefined 'id' property error

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -93,7 +93,7 @@ function useUseAuthFromBetterAuth(authClient: AuthClient) {
       function useAuthFromBetterAuth() {
         const { data: session, isPending: isSessionPending } =
           authClient.useSession();
-        const sessionId = session?.session.id;
+        const sessionId = session?.session?.id;
         const fetchAccessToken = useCallback(
           async () => {
             try {


### PR DESCRIPTION
<!-- Describe your PR here. -->

I found that in certain situations, such as using subdomains with better auth, that `authClient.useSession()` returns undefined data. This then causes an `undefined id on undefined` error here. This fixes the issue and makes this work again.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
