### PR TITLE
docs: add conditional query execution for authenticated users

### DIFF
--- a/docs/content/docs/framework-guides/sveltekit.mdx
+++ b/docs/content/docs/framework-guides/sveltekit.mdx
@@ -373,7 +373,7 @@ Note: To add SSR support (`data.currentUser`) also add the `src/routes/+page.ser
 	const isLoading = $derived(auth.isLoading && !data.currentUser);
 	const isAuthenticated = $derived(auth.isAuthenticated || !!data.currentUser);
 
-	const currentUserResponse = useQuery(api.auth.getCurrentUser, {});
+	const currentUserResponse = useQuery(api.auth.getCurrentUser, () => (isAuthenticated ? {} : 'skip'));
 	let user = $derived(currentUserResponse.data ?? data.currentUser);
 
 	// Sign in/up form state


### PR DESCRIPTION
This PR adds a one-liner that shows how to use the [new skip query feature from convex-svelte](https://github.com/get-convex/convex-svelte/pull/39) to conditionally execute a query if a user is authenticated or not.

This solves a common question/problem and avoids a major effect in teardown error that happens if the user tries deriving from a query to run a query like so conditionally in a dynamically mounted component (Dialog, popup, etc.)([More explained in the convex-svelte docs](https://github.com/get-convex/convex-svelte?tab=readme-ov-file#troubleshooting)):

```ts
// Bad
$derived( isAuthenticated ? useQuery(api.users.queries.getActiveUser, {}) : {} );  

// Good (Enabled with convex-svelte 0.0.12
useQuery(api.auth.getCurrentUser, () => (isAuthenticated ? {} : 'skip'));
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
