### PR TITLE
docs: Add expectAuth: true option to SvelteKit guide

### DIFF
--- a/docs/content/docs/framework-guides/sveltekit.mdx
+++ b/docs/content/docs/framework-guides/sveltekit.mdx
@@ -296,7 +296,13 @@ npm install convex convex-svelte
       import { createSvelteAuthClient } from '@mmailaender/convex-better-auth-svelte/svelte'; // [!code ++]
       import { authClient } from '$lib/auth-client'; // [!code ++]
 
-      createSvelteAuthClient({ authClient }); // [!code ++]
+      createSvelteAuthClient({ // [!code ++]
+        authClient, // [!code ++]
+        // Optionally, pause queries until the user is authenticated // [!code ++]
+        options: { // [!code ++]
+          expectAuth: true // [!code ++]
+        } // [!code ++]
+      }); // [!code ++]
 
       let { children } = $props();
     </script>


### PR DESCRIPTION
Added the expectAuth: true option to the SvelteKit documentation, aligning it with the other guides.

The underlying @mmailaender/convex-better-auth-svelte library already supports passing this option through (I also tested it and it works great).