### PR TITLE
[Docs fix] Added missing baseUrl property in the auth.ts template

### DIFF
--- a/docs/content/docs/framework-guides/expo.mdx
+++ b/docs/content/docs/framework-guides/expo.mdx
@@ -122,18 +122,21 @@ description: Install and configure Convex + Better Auth for Expo.
     // The component client has methods needed for integrating Convex with Better Auth,
     // as well as helper methods for general use.
     export const authComponent = createClient<DataModel>(components.betterAuth);
+    // This is important: retrieve the HTTP actions url from environment variables
+    const siteUrl = process.env.CONVEX_SITE_URL || "";
 
     export const createAuth = (
       ctx: GenericCtx<DataModel>,
       { optionsOnly } = { optionsOnly: false },
     ) => {
       return betterAuth({
+        baseUrl: siteUrl,
         // disable logging when createAuth is called just to generate options.
         // this is not required, but there's a lot of noise in logs without it.
         logger: {
           disabled: optionsOnly,
         },
-        trustedOrigins: ["your-scheme://"],
+        trustedOrigins: ["your-scheme://", siteUrl],
         database: authComponent.adapter(ctx),
         // Configure simple, non-verified email/password to get started
         emailAndPassword: {


### PR DESCRIPTION
<!-- Describe your PR here. -->
- The expo framework guide was missing an important property, `baseUrl`, from the auth.ts template file. For people who are new to convex and better auth it may not be obvious as to what goes in there, and I personally fell into that trap. 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Expo framework guide with improved Better Auth configuration, including proper setup of site URL from environment variables and trusted origins for enhanced security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->