### PR TITLE
(fix) Prevent better-auth from converting dates to ISO strings

### DIFF
--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -129,8 +129,10 @@ export const convexAdapter = <
       mapKeysTransformOutput: {
         _id: "id",
       },
-      // Dates provided as strings
-      supportsDates: false,
+      // Convex does not support dates.
+      // We need to keep this true so that better-auth can use the custom transforms below to convert dates to numbers,
+      // instead of ISO strings.
+      supportsDates: true,
       // Convert dates to numbers. This aligns with how
       // Convex stores _creationTime and avoids a breaking change.
       customTransformInput: ({ data, fieldAttributes }) => {


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR enables `supportsDates` in the adapter config.

With `supportsDates: false`, better-auth automatically converts dates to ISO strings (see `@better-auth/core/src/db/adapter/factory.ts`). This breaks all the logic in this package that relies on `instanceof Date` to convert them to timestamp numbers instead.

With `supportsDates: true`, the existing logic to convert to timestamps can run.

There's probably more bugs downstream of this, but the one I came across was the reset password flow not working. By default better-auth cleans all expired verification tokens when fetching a token. With the broken logic, it was trying to do `lt: '2025-12-20...` which was always true. So when the user tries to submit the token to reset their password, its already deleted...

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
