### PR TITLE
chore: remove debug console.log statements from convex plugin

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -321,7 +321,6 @@ export const convex = (opts: {
         },
         {
           matcher: (ctx) => {
-            console.log(ctx.path, ctx.context.session);
             return (
               ctx.path?.startsWith("/sign-out") ||
               ctx.path?.startsWith("/delete-user") ||
@@ -329,7 +328,6 @@ export const convex = (opts: {
             );
           },
           handler: createAuthMiddleware(async (ctx) => {
-            console.log("clearing jwt cookie");
             const jwtCookie = ctx.context.createAuthCookie(JWT_COOKIE_NAME, {
               maxAge: 0,
             });


### PR DESCRIPTION
## Summary
- Remove leftover debug `console.log` statements from the convex plugin that were logging request paths and cookie clearing messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Cleaned up debug logging statements to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->