### PR TITLE
Fix key error

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -62,8 +62,9 @@ const isUniqueField = (
   model: string,
   field: string
 ) => {
-  const fields =
-    betterAuthSchema[model as keyof typeof betterAuthSchema]["fields"];
+  const fields = Object.values(betterAuthSchema).find(
+    (value) => value.modelName === model
+  )?.fields;
   if (!fields) {
     return false;
   }


### PR DESCRIPTION
This PR fixes a key error that occurs when Better Auth tables are renamed.

The `model` argument that we get is the new name, but the keys of `betterAuthSchema` are the original names.

The solution is the find the value of `betterAuthSchema` with `modelName` equal to `model`.

This should be fast because the Better Auth schema does not have many tables.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the robustness of uniqueness field validation checks to handle various model configuration types more reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->