### PR TITLE
Fix: set convex_jwt cookie after passkey sign-in

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -294,6 +294,7 @@ export const convex = (opts: {
                 ctx.path.startsWith("/email-otp/verify-email") ||
                 ctx.path.startsWith("/phone-number/verify") ||
                 ctx.path.startsWith("/siwe/verify") ||
+                ctx.path.startsWith("/passkey/verify-authentication") ||
                 (ctx.path.startsWith("/get-session") && ctx.context.session)
             );
           },


### PR DESCRIPTION
## Problem

The after hook in the Convex plugin that sets the `convex_jwt` cookie doesn't include `/passkey/verify-authentication` in its path matcher. Every other sign-in method (`/sign-in`, `/callback`, `/magic-link/verify`, etc.) is covered — passkey was missed.

Because of this, passkey sign-in creates a valid session and sets `better-auth.session_token`, but the `convex_jwt` cookie never gets written. `getToken()` returns `undefined` on the server side and the user gets redirected back to login.

## Fix

Add `ctx.path.startsWith("/passkey/verify-authentication")` to the matcher. This is the only passkey endpoint that creates a new session — the others either require an existing session or don't create one.