### PR TITLE
fix: prevent request hanging in Bun by selectively forwarding headers

### DIFF
--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -76,6 +76,7 @@ export const convexBetterAuthNextJs = (
       const headers = await (await import("next/headers.js")).headers();
       const mutableHeaders = new Headers(headers);
       mutableHeaders.delete("content-length");
+      mutableHeaders.delete("transfer-encoding");
       return getToken(siteUrl, mutableHeaders, { ...opts, forceRefresh });
     }
   );

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -88,6 +88,7 @@ export const convexBetterAuthReactStart = (
     const headers = getRequestHeaders();
     const mutableHeaders = new Headers(headers);
     mutableHeaders.delete("content-length");
+    mutableHeaders.delete("transfer-encoding");
     return getToken(siteUrl, mutableHeaders, opts);
   });
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR fixes an issue where internal authentication requests hang indefinitely when running in the Bun runtime.

When using Bun with Next.js, the integration encounters two main issues during server-side authentication:

- Read-only Headers: next/headers() returns a read-only Headers object.
- Header Forwarding (Content-Length): All headers from the original incoming request were being forwarded to the internal Convex auth request. If the original request was a POST (e.g., a form submission), it included a Content-Length header. Forwarding this to an internal request with no body causes the server to wait indefinitely for data that never arrives.


Solution:

Modified the getToken logic to:
- Create a new, mutable Headers object.
- Selectively forward only the essential headers (cookie and user-agent).
This prevents problematic headers like Content-Length or Host from being incorrectly carried over.

Fixes #249




<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token retrieval to forward incoming request headers (including cookies and user-agent) while stripping problematic content-length and transfer-encoding metadata, reducing intermittent authentication and session errors.
  * Applied consistently across Next.js and React starter flows for more dependable authentication behavior for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->