### PR TITLE
fix(cross-domain): only rewrite set-cookie for cross-domain requests

### DIFF
--- a/src/plugins/cross-domain/index.ts
+++ b/src/plugins/cross-domain/index.ts
@@ -129,7 +129,12 @@ export const crossDomain = ({ siteUrl }: { siteUrl: string }) => {
       after: [
         {
           matcher(ctx) {
-            return !isExpoNative(ctx);
+            return (
+              Boolean(
+                ctx.request?.headers.get("better-auth-cookie") ||
+                  ctx.headers?.get("better-auth-cookie")
+              ) && !isExpoNative(ctx)
+            );
           },
           handler: createAuthMiddleware(async (ctx) => {
             const setCookie = ctx.context.responseHeaders?.get("set-cookie");


### PR DESCRIPTION
## Summary
- The cross-domain plugin's after hook was unconditionally rewriting `set-cookie` to `Set-Better-Auth-Cookie` for all non-Expo requests, breaking plugins like `oidcProvider` that depend on `set-cookie` being present
- Now the after hook gates on the `better-auth-cookie` request header — matching the before hook's existing behavior — so only actual cross-domain client requests get cookie rewriting

Fixes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cross-domain request validation by requiring authentication cookie presence for improved security and consistency in cross-domain middleware handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->