### PR TITLE
fix: skip expired API key deletion in query context

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -292,7 +292,7 @@ export const convex = (opts: {
             ctx.context.adapter.deleteMany = async (
               ..._args: any[]
             ) => {
-              //skip
+              return 0;
             };
             return { context: ctx };
           }),


### PR DESCRIPTION
## Summary
- No-ops `adapter.deleteMany` for `/api-key/list` and `/api-key/get` paths in query context, preventing errors from the fire-and-forget `deleteAllExpiredApiKeys` side effect
- Follows the existing session workaround pattern (`/get-session` → no-op `deleteSession`)
- Expired keys still get cleaned up during `createApiKey` in mutation context

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where expired API keys could be deleted during read-only queries. Read-only operations that list or retrieve API keys now skip deletion, preventing accidental removals.
  * Improves stability and error handling for key listing/retrieval, reducing the risk of unexpected key loss during non-mutation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->