### PR TITLE
fix: skip session refresh/delete in query context for all paths

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -277,12 +277,15 @@ export const convex = (opts: {
             ) => {
               //skip
             };
+            const knownSafePaths = ["/api-key/list", "/api-key/get"];
             const noopWrite = (method: string) => {
               return async (..._args: any[]) => {
-                // eslint-disable-next-line no-console
-                console.warn(
-                  `[convex-better-auth] Write operation "${method}" skipped in query context for ${ctx.path}`
-                );
+                if (!knownSafePaths.includes(ctx.path)) {
+                  // eslint-disable-next-line no-console
+                  console.warn(
+                    `[convex-better-auth] Write operation "${method}" skipped in query context for ${ctx.path}`
+                  );
+                }
                 return 0;
               };
             };


### PR DESCRIPTION
## Summary
- Broadens the existing `/get-session` query context guard to match all paths
- No-ops all adapter write methods (create, update, updateMany, delete, deleteMany) in query context with a console warning for unknown paths
- Session middleware runs inline in many endpoints (organization, api-key, etc.) and tries to delete expired sessions or refresh valid ones, both requiring mutation context. Other plugins have fire-and-forget write side effects (expired api-key cleanup, etc.) that also fail in query context.

Fixes #178
Fixes #160
Completes the fix for #100 (previously only handled `/get-session`)