### PR TITLE
fix(package): remove react-dom peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
   "peerDependencies": {
     "better-auth": "1.4.9",
     "convex": "^1.25.0",
-    "react": "^18.3.1 || ^19.0.0",
-    "react-dom": "^18.3.1 || ^19.0.0"
+    "react": "^18.3.1 || ^19.0.0"
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",


### PR DESCRIPTION
Removes `react-dom` from `peerDependencies`. 

There are zero imports of `react-dom`, `ReactDOM`, `createRoot`, `hydrateRoot`, `flushSync`, or `createPortal` across all 32 files in `src/`. None of the exports touch it, not `/react`, `/nextjs`, or `/react-start`. 

The declaration was dead, generating peer dep warnings in `bun` and `pnpm` projects that don't use `react-dom`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated peer dependency configuration by removing the react-dom requirement while maintaining React peer dependency support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->