### PR TITLE
chore: skip Vercel builds for non-docs changes

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- docs/"
+}


### PR DESCRIPTION
Adds a `vercel.json` with an `ignoreCommand` so Vercel skips builds when a PR doesn't touch the `docs/` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration settings.

---

**Note:** This release contains internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->