### PR TITLE
docs: add callout to betterAuth/auth.ts usage in local install for v0.10 migration guide

### DIFF
--- a/docs/content/docs/migrations/migrate-to-0-10.mdx
+++ b/docs/content/docs/migrations/migrate-to-0-10.mdx
@@ -525,6 +525,12 @@ The following steps are only necessary for apps using
 Remove `getStaticAuth` in `convex/betterAuth/auth.ts` and replace it with a
 simple `createAuth`
 
+<Callout>
+  This file should _only_ have your `auth` export for schema generation, and no
+  other code. If this file is imported at runtime it will trigger errors due to
+  missing environment variables.
+</Callout>
+
 ```ts title="convex/betterAuth/auth.ts"
 import { getStaticAuth } from "@convex-dev/better-auth"; // [!code --]
 import { v } from "convex/values";


### PR DESCRIPTION
This PR is related to #255 and adds [the callout from the local installation docs](https://github.com/get-convex/better-auth/commit/e985d26675da02f0943dc436bb8aef6789d01e02) to the v0.10 migration guide so others upgrading from an older version won't run into the same problem I did.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification in the migration guide regarding proper auth.ts usage patterns and potential runtime errors related to environment variables during authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->