### PR TITLE
fix(component): include better-auth admin plugin fields in schema

### DIFF
--- a/src/auth-options.ts
+++ b/src/auth-options.ts
@@ -1,5 +1,6 @@
 import type { BetterAuthOptions } from "better-auth/minimal";
 import {
+  admin,
   anonymous,
   bearer,
   emailOTP,
@@ -24,6 +25,7 @@ export const options = {
     storage: "database",
   },
   plugins: [
+    admin(),
     twoFactor(),
     anonymous(),
     username(),

--- a/src/component/adapterTest.ts
+++ b/src/component/adapterTest.ts
@@ -5,6 +5,7 @@ import { action } from "./_generated/server.js";
 import type { GenericActionCtx } from "convex/server";
 import type { DataModel } from "./_generated/dataModel.js";
 import type { BetterAuthOptions } from "better-auth";
+import { admin } from "better-auth/plugins";
 import type { EmptyObject } from "convex-helpers";
 
 // Hide vitest imports from esbuild, keep them out of the bundle
@@ -481,6 +482,75 @@ function runCustomAdapterTests({
         data: { name: "foo", email: "foo@bar.com" },
       })
     ).rejects.toThrow("user email already exists");
+  });
+
+  test("should handle admin plugin user fields", async () => {
+    const adapter = await getAdapter({ plugins: [admin()] });
+    const banExpires = new Date(Date.now() + 60_000).toISOString();
+    const user = await adapter.create({
+      model: "user",
+      data: {
+        name: "admin user",
+        email: "admin@bar.com",
+        role: "user",
+        banned: false,
+        banReason: null,
+        banExpires: null,
+      },
+    });
+
+    expect(user.role).toEqual("user");
+    expect(user.banned).toEqual(false);
+
+    const updatedUser = await adapter.update({
+      model: "user",
+      where: [{ field: "id", value: user.id }],
+      update: {
+        role: "admin",
+        banned: true,
+        banReason: "test",
+        banExpires,
+      },
+    });
+
+    expect(updatedUser?.role).toEqual("admin");
+    expect(updatedUser?.banned).toEqual(true);
+    expect(updatedUser?.banReason).toEqual("test");
+    expect(updatedUser?.banExpires).toEqual(new Date(banExpires));
+  });
+
+  test("should handle admin plugin session impersonation field", async () => {
+    const adapter = await getAdapter({ plugins: [admin()] });
+    const user = await adapter.create({
+      model: "user",
+      data: {
+        name: "session user",
+        email: "session@bar.com",
+      },
+    });
+
+    const session = await adapter.create({
+      model: "session",
+      data: {
+        token: "token",
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        userId: user.id,
+        updatedAt: new Date().toISOString(),
+        impersonatedBy: "admin-user-id",
+      },
+    });
+
+    expect(session.impersonatedBy).toEqual("admin-user-id");
+
+    const updatedSession = await adapter.update({
+      model: "session",
+      where: [{ field: "id", value: session.id }],
+      update: {
+        impersonatedBy: "another-admin",
+      },
+    });
+
+    expect(updatedSession?.impersonatedBy).toEqual("another-admin");
   });
 
   test("should be able to compare against a date", async () => {

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -20,6 +20,10 @@ export const tables = {
     phoneNumber: v.optional(v.union(v.null(), v.string())),
     phoneNumberVerified: v.optional(v.union(v.null(), v.boolean())),
     userId: v.optional(v.union(v.null(), v.string())),
+    role: v.optional(v.union(v.null(), v.string())),
+    banned: v.optional(v.union(v.null(), v.boolean())),
+    banReason: v.optional(v.union(v.null(), v.string())),
+    banExpires: v.optional(v.union(v.null(), v.number())),
   })
     .index("email_name", ["email", "name"])
     .index("name", ["name"])
@@ -34,6 +38,7 @@ export const tables = {
     ipAddress: v.optional(v.union(v.null(), v.string())),
     userAgent: v.optional(v.union(v.null(), v.string())),
     userId: v.string(),
+    impersonatedBy: v.optional(v.union(v.null(), v.string())),
   })
     .index("expiresAt", ["expiresAt"])
     .index("expiresAt_userId", ["expiresAt", "userId"])


### PR DESCRIPTION
This fixes a schema/runtime mismatch when using Better Auth `admin()` with the Convex component install.

The component schema now includes the admin plugin fields used at runtime (`user.role`, `user.banned`, `user.banReason`, `user.banExpires`, and `session.impersonatedBy`), so adapter create/update calls no longer fail validation.

It also adds adapter tests that cover these admin user/session fields.

Fixes #285 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin plugin support: user role management, banning (reason and optional expiration), and session impersonation.
  * Extended user and session data with optional fields to enable these admin capabilities.

* **Tests**
  * Added tests validating admin behaviors: user field updates (role, banned, banReason, banExpires) and session impersonation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->