### PR TITLE
docs: update convex-svelte package references to @mmailaender/convex-svelte

### DIFF
--- a/docs/content/docs/framework-guides/sveltekit.mdx
+++ b/docs/content/docs/framework-guides/sveltekit.mdx
@@ -22,7 +22,7 @@ steps in prerequisites are completed.
 ### Install convex
 
 ```npm
-npm install convex convex-svelte
+npm install convex @mmailaender/convex-svelte
 ```
 
 </div>
@@ -279,7 +279,7 @@ npm install convex convex-svelte
     ### Set up Convex client provider
 
     Initialize the Convex client with auth in your app.
-    Note: `createSvelteAuthClient` includes already `setupConvex()` from convex-svelte.
+    Note: `createSvelteAuthClient` includes already `setupConvex()` from `@mmailaender/convex-svelte`.
 
     ```ts title="src/routes/+layout.svelte"
     <script lang="ts">
@@ -353,7 +353,7 @@ usage. Below are usage notes specific to SvelteKit.
 <script lang="ts">
 	import { authClient } from '$lib/auth-client';
 	import { api } from '$convex/_generated/api';
-	import { useQuery } from 'convex-svelte';
+	import { useQuery } from '@mmailaender/convex-svelte';
 	import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 
 	let { data } = $props();
@@ -561,7 +561,7 @@ should only run once the user is authenticated.
 
 ```ts title="src/routes/+page.svelte"
 import { api } from "$convex/_generated/api";
-import { useQuery } from "convex-svelte";
+import { useQuery } from "@mmailaender/convex-svelte";
 import { useAuth } from "@mmailaender/convex-better-auth-svelte/svelte";
 
 const auth = useAuth();
@@ -694,7 +694,7 @@ load.
     ```ts title="src/routes/+page.svelte"
     <script lang="ts">
       import { api } from '$convex/_generated/api';
-      import { useQuery } from 'convex-svelte';
+      import { useQuery } from '@mmailaender/convex-svelte';
       import { useAuth } from '@mmailaender/convex-better-auth-svelte/svelte';
 
       let { data } = $props();


### PR DESCRIPTION
This PR updates the Svelte documentation to reference **`@mmailaender/convex-svelte`** instead of `convex-svelte`.

`@mmailaender/convex-svelte` continues development of the Svelte client and adds several community-requested improvements such as **pagination** and **basic auth helpers**, helping bring the Svelte ecosystem closer to feature parity with the Convex React client.

In this context, **`convex-better-auth-svelte`** has also been refactored to build on primitives now provided by the extended client:

* refactor to use primitives now provided by `@mmailaender/convex-svelte`
* move shared primitives out of `convex-better-auth-svelte` into `@mmailaender/convex-svelte`
* keep `convex-better-auth-svelte` focused on Better Auth integration

`@mmailaender/convex-svelte` currently acts as an **intermediate continuation** while work on the official `convex-svelte` package evolves.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SvelteKit framework integration guide to reflect current package references in installation steps and code examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->