### PR TITLE
fix: prevent proxy compression from breaking server-side token fetch

### DIFF
--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -77,6 +77,7 @@ export const convexBetterAuthNextJs = (
       const mutableHeaders = new Headers(headers);
       mutableHeaders.delete("content-length");
       mutableHeaders.delete("transfer-encoding");
+      mutableHeaders.set("accept-encoding", "identity");
       return getToken(siteUrl, mutableHeaders, { ...opts, forceRefresh });
     }
   );

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -89,6 +89,7 @@ export const convexBetterAuthReactStart = (
     const mutableHeaders = new Headers(headers);
     mutableHeaders.delete("content-length");
     mutableHeaders.delete("transfer-encoding");
+    mutableHeaders.set("accept-encoding", "identity");
     return getToken(siteUrl, mutableHeaders, opts);
   });
 


### PR DESCRIPTION
Set `accept-encoding: identity` on internal `getToken()` fetches in both Next.js and React Start helpers, preventing reverse proxies from compressing the token response.

Fixes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved request header handling in authentication token fetch operations to ensure consistent and proper encoding behavior across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->