### PR TITLE
feat: allow setting basePath for getToken

### DIFF
--- a/docs/content/docs/framework-guides/next.mdx
+++ b/docs/content/docs/framework-guides/next.mdx
@@ -191,6 +191,8 @@ description: Install and configure Convex + Better Auth for Next.js.
     } = convexBetterAuthNextJs({
       convexUrl: process.env.NEXT_PUBLIC_CONVEX_URL!,
       convexSiteUrl: process.env.NEXT_PUBLIC_CONVEX_SITE_URL!,
+      // Optional, defaults to "/api/auth"
+      basePath: "/custom/auth/path",
     });
     ```
 

--- a/docs/content/docs/framework-guides/tanstack-start.mdx
+++ b/docs/content/docs/framework-guides/tanstack-start.mdx
@@ -208,6 +208,8 @@ description: Install and configure Convex + Better Auth for TanStack Start.
     } = convexBetterAuthReactStart({
       convexUrl: process.env.VITE_CONVEX_URL!,
       convexSiteUrl: process.env.VITE_CONVEX_SITE_URL!,
+      // Optional, defaults to "/api/auth"
+      basePath: "/custom/auth/path",
     })
     ```
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -137,8 +137,12 @@ export const getToken = async (
   opts?: GetTokenOptions
 ) => {
   const fetchToken = async () => {
+    const basePath = opts?.basePath
+      ? (opts.basePath.startsWith("/") ? opts.basePath : `/${opts.basePath}`)
+          .replace(/\/+$/, "")
+      : "/api/auth";
     const { data } = await betterFetch<{ token: string }>(
-      `${opts?.basePath ?? "/api/auth"}/convex/token`,
+      `${basePath}/convex/token`,
       {
         baseURL: siteUrl,
         headers,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -121,6 +121,7 @@ export const requireRunMutationCtx = <DataModel extends GenericDataModel>(
 };
 
 export type GetTokenOptions = {
+  basePath?: string;
   forceRefresh?: boolean;
   cookiePrefix?: string;
   jwtCache?: {
@@ -137,7 +138,7 @@ export const getToken = async (
 ) => {
   const fetchToken = async () => {
     const { data } = await betterFetch<{ token: string }>(
-      "/api/auth/convex/token",
+      `${opts?.basePath ?? "/api/auth"}/convex/token`,
       {
         baseURL: siteUrl,
         headers,


### PR DESCRIPTION
Update `getToken`'s `GetTokenOptions` to include `basePath` so it can be set to something other than the default `/api/auth`

Closes https://github.com/get-convex/better-auth/issues/307

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `basePath` parameter to customize the authentication API route path, allowing flexible configuration of the auth endpoint.

* **Documentation**
  * Updated framework guides with examples demonstrating the new `basePath` configuration option for Next.js and TanStack Start integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->