### PR TITLE
fix: upsert rateLimit entries to prevent duplicate key errors

### DIFF
--- a/src/client/create-api.ts
+++ b/src/client/create-api.ts
@@ -77,6 +77,34 @@ export const createApi = <Schema extends SchemaDefinition<any, any>>(
         onCreateHandle: v.optional(v.string()),
       },
       handler: async (ctx, args) => {
+        // For rateLimit entries, use upsert semantics: the rate limiter's
+        // `set(key, value, _update)` can race or pass _update=false even
+        // when a record with the same key already exists, causing a unique
+        // constraint violation. Instead of throwing, find the existing
+        // record and patch it.
+        if (args.input.model === "rateLimit" && "key" in args.input.data) {
+          const existing = await listOne(ctx, schema, betterAuthSchema, {
+            model: args.input.model,
+            where: [
+              {
+                field: "key",
+                operator: "eq",
+                value: args.input.data.key as string,
+              },
+            ],
+          });
+          if (existing) {
+            await ctx.db.patch(
+              existing._id as GenericId<string>,
+              args.input.data
+            );
+            const updatedDoc = await ctx.db.get(
+              existing._id as GenericId<string>
+            );
+            return selectFields(updatedDoc, args.select);
+          }
+        }
+
         await checkUniqueFields(
           ctx,
           schema,


### PR DESCRIPTION
## Summary

- When `rateLimit.storage` is `"database"`, `adapter:create` throws `"rateLimit key already exists"` on concurrent or repeated auth requests, blocking all auth flows
- The root cause is in better-auth core's rate limiter passing `_update=false` to `set()` even when a record exists, but the Convex adapter can handle this gracefully
- This fix adds upsert semantics for `rateLimit` entries: before inserting, check if a record with the same `key` exists, and if so, patch it instead of throwing

Fixes #312

## Test plan

- [ ] Configure `rateLimit: { enabled: true, storage: "database" }` in better-auth options
- [ ] Make repeated auth requests (e.g., `get-session`, OTP send) within the same rate limit window
- [ ] Verify no `"rateLimit key already exists"` errors in Convex logs
- [ ] Verify rate limiting still works correctly (requests are counted and limited)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limit handling to better manage duplicate entries. When a rate limit entry with the same key already exists, the system now intelligently updates the existing record instead of creating a duplicate. This enhancement improves data consistency, prevents potential conflicts, and maintains normal operation for creating new rate limit entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->