### PR TITLE
fix: add compound [token, expiresAt] index on session table

### DIFF
--- a/src/client/create-schema.ts
+++ b/src/client/create-schema.ts
@@ -5,7 +5,7 @@ import type { BetterAuthDBSchema, DBFieldAttribute } from "better-auth/db";
 export const indexFields = {
   account: ["accountId", ["accountId", "providerId"], ["providerId", "userId"]],
   rateLimit: ["key"],
-  session: ["expiresAt", ["expiresAt", "userId"]],
+  session: ["expiresAt", ["expiresAt", "userId"], ["token", "expiresAt"]],
   verification: ["expiresAt", "identifier"],
   user: [["email", "name"], "name", "userId"],
   oauthConsent: [["clientId", "userId"]],

--- a/src/client/create-schema.ts
+++ b/src/client/create-schema.ts
@@ -129,8 +129,8 @@ export const tables = {
       mergedIndexFields(tables)[
         tableKey as keyof typeof mergedIndexFields
       ]?.map((index) => {
-        const indexArray = Array.isArray(index) ? index.sort() : [index];
-        const indexName = indexArray.join("_");
+        const indexArray = Array.isArray(index) ? index : [index];
+        const indexName = [...indexArray].sort().join("_");
         return `.index("${indexName}", ${JSON.stringify(indexArray)})`;
       }) || [];
 

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -44,6 +44,7 @@ export const tables = {
     .index("expiresAt", ["expiresAt"])
     .index("expiresAt_userId", ["expiresAt","userId"])
     .index("token", ["token"])
+    .index("token_expiresAt", ["token","expiresAt"])
     .index("userId", ["userId"]),
   account: defineTable({
     accountId: v.string(),


### PR DESCRIPTION
## Summary
- Added compound `["token", "expiresAt"]` index to session table in both the schema generator (`create-schema.ts`) and the auto-generated component schema
- Fixes "Querying without an index" warning when using multi-session plugin, which queries by `token` eq + `expiresAt` range
- Without this compound index, the query falls back to a full table scan

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (34/34)
- [x] Verified index naming follows existing convention (`token_expiresAt`)

Fixes #305

Orchestrator: Zeta — VantageOS Team Dev | 2026-04-06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a composite index for sessions to improve session token lookup and expiration handling performance. This results in faster authentication and session-validation operations, reduced latency during token checks, and more efficient expiration processing. The schema generation was also made more robust to prevent unintended mutations during index name computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->