### PR TITLE
fix: accept `mode` field in where clause validators

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -41,6 +41,7 @@ export const adapterWhereValidator = v.object({
     v.null()
   ),
   connector: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+  mode: v.optional(v.string()),
 });
 
 export const adapterArgsValidator = v.object({

--- a/src/client/create-api.ts
+++ b/src/client/create-api.ts
@@ -55,6 +55,7 @@ const whereValidator = (
       v.null()
     ),
     connector: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+    mode: v.optional(v.string()),
   });
 
 export const createApi = <Schema extends SchemaDefinition<any, any>>(


### PR DESCRIPTION
## Summary

- better-auth 1.6.0 sends `mode: "sensitive"` in where clauses for session token lookups (e.g., `get-session`, `convex/token`)
- The Convex adapter's `adapterWhereValidator` and typed `whereValidator` in `create-api.ts` reject this extra field, causing `ArgumentValidationError` on every session-related call
- This adds `mode: v.optional(v.string())` to both validators

### Error from Convex logs

```
ArgumentValidationError: Object contains extra field `mode` that is not in the validator.
Path: .where[0]
Object: {connector: "AND", field: "token", mode: "sensitive", operator: "eq", value: "..."}
```

## Test plan

- [ ] Deploy with better-auth 1.6.0 and `@convex-dev/better-auth` with this fix
- [ ] Verify `get-session` and `convex/token` calls no longer throw `ArgumentValidationError`
- [ ] Verify session token lookups still work correctly (case-sensitive matching)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `mode` parameter in `where` filters, providing enhanced control across update, delete, and query operations (`updateOne`, `updateMany`, `deleteOne`, `deleteMany`, and related queries).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->