### PR TITLE
fix: add missing mode field to Convex where
  validators

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -41,6 +41,7 @@ export const adapterWhereValidator = v.object({
     v.null()
   ),
   connector: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+  mode: v.optional(v.union(v.literal("sensitive"), v.literal("insensitive"))),
 });
 
 export const adapterArgsValidator = v.object({

--- a/src/client/create-api.ts
+++ b/src/client/create-api.ts
@@ -55,6 +55,7 @@ const whereValidator = (
       v.null()
     ),
     connector: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+    mode: v.optional(v.union(v.literal("sensitive"), v.literal("insensitive"))),
   });
 
 export const createApi = <Schema extends SchemaDefinition<any, any>>(


### PR DESCRIPTION
## Summary                                                                                     
  - Better Auth now sends a mode field (sensitive | insensitive) in where clauses
  - The Convex validators in adapterWhereValidator and whereValidator did not accept this field,       
  causing 111 test failures
  - Added mode as an optional field to both validators

  ## Changes
  - src/client/adapter-utils.ts — added mode to adapterWhereValidator
  - src/client/create-api.ts — added mode to local whereValidator

  ## Test plan
  - [x] All 165 tests passing (previously 111 failing)
  - [x] No type errors
  - [x] Lint clean

  ----

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
  contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query filters now support an optional `mode` parameter to specify case-sensitive (`"sensitive"`) or case-insensitive (`"insensitive"`) string matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->