### PR TITLE
fix: Preserve forwarded host headers for dynamic base URLs

### DIFF
--- a/src/client/create-client.test.ts
+++ b/src/client/create-client.test.ts
@@ -109,6 +109,46 @@ describe("createClient route registration", () => {
     expect(createAuth).toHaveBeenCalledTimes(2);
   });
 
+  it("restores preserved forwarded host headers before calling auth.handler", async () => {
+    const client = createClient(component);
+    const http = httpRouter();
+    const handler = vi.fn(async (_request: Request) => new Response("ok"));
+    const createAuth = vi.fn(() => ({
+      handler,
+      options: {
+        trustedOrigins: ["https://app.example.com"],
+      },
+      $context: Promise.resolve({
+        options: {
+          trustedOrigins: ["https://app.example.com"],
+        },
+      }),
+    }));
+
+    client.registerRoutes(http, createAuth);
+
+    const getHandler = getRouteHandler(http, "/api/auth/test", "GET");
+    expect(getHandler).toBeTruthy();
+    await getHandler!._handler(
+      {},
+      new Request("https://adjective-animal-123.convex.site/api/auth/test", {
+        method: "GET",
+        headers: {
+          host: "deployment.convex.site",
+          "x-forwarded-host": "deployment.convex.site",
+          "x-forwarded-proto": "https",
+          "x-better-auth-forwarded-host": "app.example.com",
+          "x-better-auth-forwarded-proto": "https",
+        },
+      })
+    );
+
+    const forwardedRequest = handler.mock.calls[0]?.[0];
+    expect(forwardedRequest).toBeInstanceOf(Request);
+    expect(forwardedRequest.headers.get("x-forwarded-host")).toBe("app.example.com");
+    expect(forwardedRequest.headers.get("x-forwarded-proto")).toBe("https");
+  });
+
   it("registerRoutesLazy resolves trustedOrigins lazily when needed", async () => {
     const client = createClient(component);
     const http = httpRouter();

--- a/src/client/create-client.ts
+++ b/src/client/create-client.ts
@@ -87,6 +87,27 @@ type RegisterRoutesLazyOptions = {
   cors?: RouteCorsOptions;
 };
 
+const restoreOriginalForwardedHeaders = (request: Request) => {
+  const originalHost = request.headers.get("x-better-auth-forwarded-host");
+  const originalProto = request.headers.get("x-better-auth-forwarded-proto");
+
+  if (!originalHost && !originalProto) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+
+  if (originalHost) {
+    headers.set("x-forwarded-host", originalHost);
+  }
+
+  if (originalProto) {
+    headers.set("x-forwarded-proto", originalProto);
+  }
+
+  return new Request(request, { headers });
+};
+
 /**
  * Backend API for the Better Auth component.
  * Responsible for exposing the `client` and `triggers` APIs to the client, http
@@ -375,7 +396,8 @@ export const createClient = <
           console.log("request headers", request.headers);
         }
         const auth = createAuth(ctx as any);
-        const response = await auth.handler(request);
+        const normalizedRequest = restoreOriginalForwardedHeaders(request);
+        const response = await auth.handler(normalizedRequest);
         if (config?.verbose) {
           // eslint-disable-next-line no-console
           console.log("response headers", response.headers);
@@ -494,7 +516,8 @@ export const createClient = <
           console.log("request headers", request.headers);
         }
         const auth = createAuth(ctx as any);
-        const response = await auth.handler(request);
+        const normalizedRequest = restoreOriginalForwardedHeaders(request);
+        const response = await auth.handler(normalizedRequest);
         if (config?.verbose) {
           // eslint-disable-next-line no-console
           console.log("response headers", response.headers);

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -46,6 +46,10 @@ const handler = (request: Request, siteUrl: string) => {
   const newRequest = new Request(nextUrl, request);
   newRequest.headers.set("accept-encoding", "application/json");
   newRequest.headers.set("host", new URL(siteUrl).host);
+  newRequest.headers.set("x-forwarded-host", requestUrl.host);
+  newRequest.headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+  newRequest.headers.set("x-better-auth-forwarded-host", requestUrl.host);
+  newRequest.headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   return fetch(newRequest, { method: request.method, redirect: "manual" });
 };
 

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -65,6 +65,10 @@ const handler = (request: Request, opts: { convexSiteUrl: string }) => {
   const headers = new Headers(request.headers);
   headers.set("accept-encoding", "application/json");
   headers.set("host", new URL(opts.convexSiteUrl).host);
+  headers.set("x-forwarded-host", requestUrl.host);
+  headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+  headers.set("x-better-auth-forwarded-host", requestUrl.host);
+  headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   return fetch(nextUrl, {
     method: request.method,
     headers,


### PR DESCRIPTION
Better Auth 1.5 added dynamic baseURL support based on trusted request hosts. In Convex deployments, framework adapters proxy auth requests through the Convex site URL, which can replace the original app host before auth.handler runs.

This change preserves the original forwarded host/protocol in framework adapters using internal x-better-auth-forwarded-host and x-better-auth-forwarded-proto headers, then restores them before calling auth.handler.

This keeps Better Auth’s trustedOrigins / dynamic base URL validation aligned with the user-facing app URL, so OAuth callbacks and other generated auth URLs use the correct origin in proxied deployments.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication request handling to correctly preserve original host and protocol information when operating behind proxies or load balancers, ensuring proper forwarded header restoration throughout the request pipeline.

* **Tests**
  * Added test coverage validating correct restoration of forwarded headers during authentication request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->