### PR TITLE
fix: accept where.mode field from Better Auth >=1.6

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -41,6 +41,7 @@ export const adapterWhereValidator = v.object({
     v.null()
   ),
   connector: v.optional(v.union(v.literal("AND"), v.literal("OR"))),
+  mode: v.optional(v.union(v.literal("sensitive"), v.literal("insensitive"))),
 });
 
 export const adapterArgsValidator = v.object({


### PR DESCRIPTION
## Summary
- Added optional `mode` field (`"sensitive" | "insensitive"`) to `adapterWhereValidator`
- Better Auth >=1.6 sends `mode` in every where clause; without this, all auth flows throw `ArgumentValidationError`
- The field is accepted but currently ignored (Convex doesn't support case-insensitive queries)

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (34/34)

Fixes #324

Orchestrator: Zeta — VantageOS Team Dev | 2026-04-09


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Added support for case sensitivity modes in where-clause filtering configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->