### PR TITLE
fix(react): drop cached JWT when sessionId rotates

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -105,9 +105,13 @@ function useUseAuthFromBetterAuth(
   authClient: AuthClient,
   initialToken?: string | null
 ) {
-  const [cachedToken, setCachedToken] = useState<string | null>(
-    initialTokenUsed ? null : (initialToken ?? null)
-  );
+  const initial = initialTokenUsed ? null : (initialToken ?? null);
+  const cachedTokenRef = useRef<string | null>(initial);
+  const [cachedToken, setCachedTokenState] = useState<string | null>(initial);
+  const setCachedToken = (value: string | null) => {
+    cachedTokenRef.current = value;
+    setCachedTokenState(value);
+  };
   const pendingTokenRef = useRef<Promise<string | null> | null>(null);
   useEffect(() => {
     if (!initialTokenUsed) {
@@ -121,6 +125,7 @@ function useUseAuthFromBetterAuth(
         const { data: session, isPending: isSessionPending } =
           authClient.useSession();
         const sessionId = session?.session?.id;
+        const lastSessionIdRef = useRef<string | null | undefined>(sessionId);
         useEffect(() => {
           if (!session && !isSessionPending && cachedToken) {
             setCachedToken(null);
@@ -130,31 +135,45 @@ function useUseAuthFromBetterAuth(
           async ({
             forceRefreshToken = false,
           }: { forceRefreshToken?: boolean } = {}) => {
-            if (cachedToken && !forceRefreshToken) {
-              return cachedToken;
+            if (
+              sessionId !== undefined &&
+              lastSessionIdRef.current !== undefined &&
+              sessionId !== lastSessionIdRef.current
+            ) {
+              cachedTokenRef.current = null;
+              pendingTokenRef.current = null;
+              setCachedTokenState(null);
+            }
+            lastSessionIdRef.current = sessionId;
+            if (cachedTokenRef.current && !forceRefreshToken) {
+              return cachedTokenRef.current;
             }
             if (!forceRefreshToken && pendingTokenRef.current) {
               return pendingTokenRef.current;
             }
-            pendingTokenRef.current = authClient.convex
+            const tokenPromise = authClient.convex
               .token({ fetchOptions: { throw: false } })
               .then(({ data }) => {
+                if (pendingTokenRef.current !== tokenPromise) return null;
                 const token = data?.token || null;
                 setCachedToken(token);
                 return token;
               })
               .catch(() => {
+                if (pendingTokenRef.current !== tokenPromise) return null;
                 setCachedToken(null);
                 return null;
               })
               .finally(() => {
-                pendingTokenRef.current = null;
+                if (pendingTokenRef.current === tokenPromise) {
+                  pendingTokenRef.current = null;
+                }
               });
-            return pendingTokenRef.current;
+            pendingTokenRef.current = tokenPromise;
+            return tokenPromise;
           },
           // Build a new fetchAccessToken to trigger setAuth() whenever the
           // session changes.
-          // eslint-disable-next-line react-hooks/exhaustive-deps
           [sessionId]
         );
         return useMemo(


### PR DESCRIPTION
`cachedToken` in `ConvexBetterAuthProvider` doesn't get cleared when the session id changes (only on logout). So right after a session rotation (password change), the next call to `fetchAccessToken({ forceRefreshToken: false })` hands back the JWT for the now-deleted session.

This PR backs `cachedToken` with a ref so the fetcher reads the current value instead of the one captured at the last render. The rotation check runs inline in the fetcher and clears the ref when `sessionId` changes. A promise-identity guard in `.then`/`.catch`/`.finally` keeps a late-resolving stale `token()` fetch from overwriting a fresh value.

[Unit test repro](https://github.com/ramonclaudio/convex-better-auth-329-repro): 6/9 fail on `v0.12.2`, all pass with this fix.

Worth flagging: this doesn't close the visible `Invalid session ID` flicker on `changePassword({ revokeOtherSessions: true })`. Tested end-to-end on repros with real credentials ([Expo test repro](https://github.com/ramonclaudio/convex-better-auth-329-expo-repro), [TanStack test repro](https://github.com/ramonclaudio/convex-better-auth-329-tanstack-repro)) but the patched build behaves the same as vanilla on that flow. Looks like an upstream Convex issue, same shape as [convex-js#82](https://github.com/get-convex/convex-js/issues/82) but I am honestly not 100% sure. [better-auth#9345](https://github.com/better-auth/better-auth/pull/9345) is the upstream complement on the Better Auth side that would preserve the caller's session on change-password instead of rotating it.
