### PR TITLE
fix(convex-plugin): await async definePayload return value

### DIFF
--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -189,9 +189,9 @@ export const convex = (opts: {
       issuer: `${process.env.CONVEX_SITE_URL}`,
       audience: "convex",
       expirationTime: `${jwtExpirationSeconds}s`,
-      definePayload: ({ user, session }) => ({
+      definePayload: async ({ user, session }) => ({
         ...(opts.jwt?.definePayload
-          ? opts.jwt.definePayload({ user, session })
+          ? await opts.jwt.definePayload({ user, session })
           : omit(user, ["id", "image"])),
         sessionId: session.id,
         iat: Math.floor(new Date().getTime() / 1000),


### PR DESCRIPTION
Fixes #335

## Summary

The convex plugin's JWT `definePayload` wrapper in `src/plugins/convex/index.ts` spreads the user-supplied `definePayload` return value synchronously. When a consumer returns a `Promise` (as the public type signature explicitly permits), the spread yields nothing and custom JWT claims are silently dropped, and only the plugin's own `sessionId` and `iat` survive into the JWT.

This PR makes the wrapper `async` and `await`s the inner call.

## Why

The public type allows async:

```ts
definePayload?: (session: { user, session }) =>
  Promise<Record<string, any>> | Record<string, any> | undefined;
```

The upstream `better-auth` jwt plugin awaits `definePayload` **once** at the outer call site (`better-auth@1.4.9`, `dist/plugins/jwt/sign.mjs:53`), so it awaits the convex plugin's sync wrapper, not the inner user function. Result: `...Promise` spreads no enumerable own properties, and every custom claim is dropped. A Convex runtime warning (`unawaited operation: [query]`) also appears when the user's async `definePayload` does DB work.

## The change (4 characters)

```diff
-      definePayload: ({ user, session }) => ({
+      definePayload: async ({ user, session }) => ({
         ...(opts.jwt?.definePayload
-          ? opts.jwt.definePayload({ user, session })
+          ? await opts.jwt.definePayload({ user, session })
           : omit(user, ["id", "image"])),
         sessionId: session.id,
         iat: Math.floor(new Date().getTime() / 1000),
       }),
```

Synchronous `definePayload` remains correct: `await` on a non-Promise is a no-op, and the outer `better-auth` code already awaits the wrapper.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — failure count unchanged vs `main` (111 pre-existing adapter test failures on both branches; no test regressions introduced). There are no existing tests that exercise `definePayload`; happy to add one if maintainers prefer.
- [x] Manually verified in a downstream app (`@convex-dev/better-auth@0.10.10` patched with this change): async `definePayload` returning `{ roles, programs, email }` now populates those claims in the JWT returned by `/api/auth/token` and `/api/auth/get-session`; without the patch the claims are absent.

## Possibly closes

May also be the root cause of #291 (First generated JWT is missing custom payload fields), see issue description for details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced JWT payload configuration in Convex authentication plugin to support asynchronous functions while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->