### PR TITLE
Retry access token fetch to handle iOS background resume

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -136,20 +136,29 @@ function useUseAuthFromBetterAuth(
             if (!forceRefreshToken && pendingTokenRef.current) {
               return pendingTokenRef.current;
             }
-            pendingTokenRef.current = authClient.convex
-              .token({ fetchOptions: { throw: false } })
-              .then(({ data }) => {
-                const token = data?.token || null;
-                setCachedToken(token);
-                return token;
-              })
-              .catch(() => {
-                setCachedToken(null);
-                return null;
-              })
-              .finally(() => {
-                pendingTokenRef.current = null;
-              });
+            pendingTokenRef.current = (async () => {
+              const maxRetries = 3;
+              for (let attempt = 0; attempt <= maxRetries; attempt++) {
+                try {
+                  const { data } = await authClient.convex.token({
+                    fetchOptions: { throw: false },
+                  });
+                  const token = data?.token || null;
+                  setCachedToken(token);
+                  return token;
+                } catch (e) {
+                  if (attempt < maxRetries) {
+                    await new Promise((r) =>
+                      setTimeout(r, 100 * 2 ** attempt)
+                    );
+                  }
+                }
+              }
+              setCachedToken(null);
+              return null;
+            })().finally(() => {
+              pendingTokenRef.current = null;
+            });
             return pendingTokenRef.current;
           },
           // Build a new fetchAccessToken to trigger setAuth() whenever the


### PR DESCRIPTION
When an iOS app is backgrounded and later resumed, the network stack may not be immediately available, causing token fetches to fail with "Network request failed". Retry up to 3 times with exponential backoff (100ms, 200ms, 400ms) before giving up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token retrieval reliability with automatic retry logic and progressive backoff timing. The system now automatically retries failed token requests with increasing delays, significantly enhancing resilience during temporary network issues or service interruptions. Strengthened concurrent request handling ensures more robust and stable authentication across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->