### PR TITLE
fix: set correct Host header in getToken like handler function 

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -137,6 +137,7 @@ export const getToken = async (
   headers: Headers,
   opts?: GetTokenOptions
 ) => {
+  headers.set("host", new URL(siteUrl).host)
   const fetchToken = async () => {
     const basePath = opts?.basePath
       ? (opts.basePath.startsWith("/") ? opts.basePath : `/${opts.basePath}`)


### PR DESCRIPTION
I am using tanstack start with convex and better auth. I followed the [guide](https://labs.convex.dev/better-auth/framework-guides/tanstack-start#installation) .

And I want to check if user is authenticated in protected layout. with `bun dev` it works fine but with docker the `getToken` fail silently and return undefined.

Currently I replace get token in my code and it works although it's not ideal.
```ts
import { convexBetterAuthReactStart } from "@convex-dev/better-auth/react-start"

export const { handler, fetchAuthQuery, fetchAuthMutation, fetchAuthAction } =
  convexBetterAuthReactStart({
    convexUrl: process.env.VITE_CONVEX_URL!,
    convexSiteUrl: process.env.VITE_CONVEX_SITE_URL!,
  })

export const getToken = async () => {
  const { getRequestHeaders } = await import("@tanstack/react-start/server")
  const headers = new Headers(getRequestHeaders())
  headers.delete("content-length")
  headers.delete("transfer-encoding")
  headers.set("accept-encoding", "identity")
  headers.set("host", new URL(process.env.VITE_CONVEX_SITE_URL!).host)

  const res = await fetch(
    `${process.env.VITE_CONVEX_SITE_URL}/api/auth/convex/token`,
    { headers }
  )
  if (!res.ok) return null
  const data = (await res.json()) as { token?: string }
  return data?.token ?? null
}

```


When getToken fetches /api/auth/convex/token from convex.site, it forwards
the incoming request headers including Host: localhost:3000 (or whatever
the app host is). Cloudflare rejects this with error 1003 "Direct IP access
not allowed" because the Host header doesn't match the target domain.
  
Fix by setting the correct Host header based on siteUrl before the fetch,
the same way the handler function in react-start/index.ts already does.  

This caused getToken to silently return undefined in environments where the
incoming Host header doesn't match the convex.site domain, such as Docker
with --host flag.

