### PR TITLE
Forward convexUrl to Next.js Convex helpers

### DIFF
--- a/src/nextjs/index.test.ts
+++ b/src/nextjs/index.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchAction = vi.fn(async () => ({ ok: true }));
+const fetchMutation = vi.fn(async () => ({ ok: true }));
+const fetchQuery = vi.fn(async () => ({ ok: true }));
+const preloadQuery = vi.fn(async () => ({ ok: true }));
+
+vi.mock("convex/nextjs", () => ({
+  fetchAction,
+  fetchMutation,
+  fetchQuery,
+  preloadQuery,
+}));
+
+vi.mock("next/headers.js", () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+
+vi.mock("../utils/index.js", () => ({
+  getToken: vi.fn(async () => ({ isFresh: true, token: "test-token" })),
+}));
+
+describe("convexBetterAuthNextJs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes convexUrl to authenticated Convex fetches", async () => {
+    const { convexBetterAuthNextJs } = await import("./index.js");
+    const query = "users:getCurrentUser" as never;
+    const mutation = "users:createOrUpdateUserFromAuth" as never;
+    const action = "admin:sendDirectSupportEmail" as never;
+
+    const auth = convexBetterAuthNextJs({
+      convexUrl: "https://example-deployment.convex.cloud",
+      convexSiteUrl: "https://example-deployment.convex.site",
+    });
+
+    await auth.preloadAuthQuery(query, { userId: "user_123" } as never);
+    await auth.fetchAuthQuery(query, { userId: "user_123" } as never);
+    await auth.fetchAuthMutation(mutation, { userId: "user_123" } as never);
+    await auth.fetchAuthAction(action, { userId: "user_123" } as never);
+
+    expect(preloadQuery).toHaveBeenCalledWith(
+      query,
+      { userId: "user_123" },
+      {
+        token: "test-token",
+        url: "https://example-deployment.convex.cloud",
+      }
+    );
+    expect(fetchQuery).toHaveBeenCalledWith(
+      query,
+      { userId: "user_123" },
+      {
+        token: "test-token",
+        url: "https://example-deployment.convex.cloud",
+      }
+    );
+    expect(fetchMutation).toHaveBeenCalledWith(
+      mutation,
+      { userId: "user_123" },
+      {
+        token: "test-token",
+        url: "https://example-deployment.convex.cloud",
+      }
+    );
+    expect(fetchAction).toHaveBeenCalledWith(
+      action,
+      { userId: "user_123" },
+      {
+        token: "test-token",
+        url: "https://example-deployment.convex.cloud",
+      }
+    );
+  });
+});

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -65,9 +65,10 @@ type OptionalArgs<FuncRef extends FunctionReference<any, any>> =
 
 const getArgsAndOptions = <FuncRef extends FunctionReference<any, any>>(
   args: OptionalArgs<FuncRef>,
-  token?: string
-): ArgsAndOptions<FuncRef, { token?: string }> => {
-  return [args[0], { token }];
+  token: string | undefined,
+  convexUrl: string
+): ArgsAndOptions<FuncRef, { token?: string; url: string }> => {
+  return [args[0], { token, url: convexUrl }];
 };
 
 export const convexBetterAuthNextJs = (
@@ -123,7 +124,7 @@ export const convexBetterAuthNextJs = (
       ...args: OptionalArgs<Query>
     ): Promise<Preloaded<Query>> => {
       return callWithToken((token?: string) => {
-        const argsAndOptions = getArgsAndOptions(args, token);
+        const argsAndOptions = getArgsAndOptions(args, token, opts.convexUrl);
         return preloadQuery(query, ...argsAndOptions);
       });
     },
@@ -132,7 +133,7 @@ export const convexBetterAuthNextJs = (
       ...args: OptionalArgs<Query>
     ): Promise<FunctionReturnType<Query>> => {
       return callWithToken((token?: string) => {
-        const argsAndOptions = getArgsAndOptions(args, token);
+        const argsAndOptions = getArgsAndOptions(args, token, opts.convexUrl);
         return fetchQuery(query, ...argsAndOptions);
       });
     },
@@ -141,7 +142,7 @@ export const convexBetterAuthNextJs = (
       ...args: OptionalArgs<Mutation>
     ): Promise<FunctionReturnType<Mutation>> => {
       return callWithToken((token?: string) => {
-        const argsAndOptions = getArgsAndOptions(args, token);
+        const argsAndOptions = getArgsAndOptions(args, token, opts.convexUrl);
         return fetchMutation(mutation, ...argsAndOptions);
       });
     },
@@ -150,7 +151,7 @@ export const convexBetterAuthNextJs = (
       ...args: OptionalArgs<Action>
     ): Promise<FunctionReturnType<Action>> => {
       return callWithToken((token?: string) => {
-        const argsAndOptions = getArgsAndOptions(args, token);
+        const argsAndOptions = getArgsAndOptions(args, token, opts.convexUrl);
         return fetchAction(action, ...argsAndOptions);
       });
     },


### PR DESCRIPTION
## Summary
- forward the configured `convexUrl` into `preloadQuery`, `fetchQuery`, `fetchMutation`, and `fetchAction` from the Next.js auth helper
- add a regression test covering all authenticated Next.js helper wrappers

## Verification
- `npm run test -- src/nextjs/index.test.ts`
- `npm run build`