### PR TITLE
fix: strip hop-by-hop headers in framework proxy handlers

### DIFF
--- a/src/nextjs/index.test.ts
+++ b/src/nextjs/index.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { convexBetterAuthNextJs } from "./index.js";
+
+const SITE_URL = "https://test.convex.site";
+const CONVEX_URL = "https://test.convex.cloud";
+
+const setup = () => {
+  const { handler } = convexBetterAuthNextJs({
+    convexUrl: CONVEX_URL,
+    convexSiteUrl: SITE_URL,
+  });
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response());
+  return { handler, fetchSpy };
+};
+
+const initOf = (spy: ReturnType<typeof vi.spyOn>): RequestInit =>
+  (spy.mock.calls[0]?.[1] as RequestInit) ?? {};
+
+const headersOf = (spy: ReturnType<typeof vi.spyOn>): Headers =>
+  new Headers(initOf(spy).headers);
+
+describe("convexBetterAuthNextJs handler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips hop-by-hop headers from the forwarded request", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      {
+        method: "POST",
+        headers: {
+          "transfer-encoding": "chunked",
+          "content-length": "42",
+          connection: "keep-alive",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ email: "test@example.com" }),
+      }
+    );
+    await handler.POST(request);
+    const headers = headersOf(fetchSpy);
+    expect(headers.get("transfer-encoding")).toBeNull();
+    expect(headers.get("content-length")).toBeNull();
+    expect(headers.get("connection")).toBeNull();
+  });
+
+  it("forwards to upstream URL preserving path and query", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email?foo=bar",
+      { method: "POST", body: "{}" }
+    );
+    await handler.POST(request);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      `${SITE_URL}/api/auth/sign-in/email?foo=bar`
+    );
+  });
+
+  it("sets host and forwarding headers", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      { method: "POST", body: "{}" }
+    );
+    await handler.POST(request);
+    const headers = headersOf(fetchSpy);
+    expect(headers.get("host")).toBe(new URL(SITE_URL).host);
+    expect(headers.get("x-forwarded-host")).toBe("app.example.com");
+    expect(headers.get("x-forwarded-proto")).toBe("https");
+    expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
+    expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
+  });
+
+  it("buffers POST body and forwards as ArrayBuffer", async () => {
+    const { handler, fetchSpy } = setup();
+    const body = JSON.stringify({ email: "test@example.com" });
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      { method: "POST", body }
+    );
+    await handler.POST(request);
+    const init = initOf(fetchSpy);
+    expect(init.body).toBeInstanceOf(ArrayBuffer);
+    expect(new TextDecoder().decode(init.body as ArrayBuffer)).toBe(body);
+  });
+
+  it("does not set body for GET requests", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/get-session",
+      { method: "GET" }
+    );
+    await handler.GET(request);
+    expect(initOf(fetchSpy).body).toBeUndefined();
+  });
+
+  it("does not set body for empty POST", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request("https://app.example.com/api/auth/sign-out", {
+      method: "POST",
+    });
+    await handler.POST(request);
+    expect(initOf(fetchSpy).body).toBeUndefined();
+  });
+});

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -40,17 +40,36 @@ const parseConvexSiteUrl = (url: string) => {
   return url;
 };
 
-const handler = (request: Request, siteUrl: string) => {
+const handler = async (request: Request, siteUrl: string) => {
   const requestUrl = new URL(request.url);
   const nextUrl = `${siteUrl}${requestUrl.pathname}${requestUrl.search}`;
-  const newRequest = new Request(nextUrl, request);
-  newRequest.headers.set("accept-encoding", "application/json");
-  newRequest.headers.set("host", new URL(siteUrl).host);
-  newRequest.headers.set("x-forwarded-host", requestUrl.host);
-  newRequest.headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
-  newRequest.headers.set("x-better-auth-forwarded-host", requestUrl.host);
-  newRequest.headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
-  return fetch(newRequest, { method: request.method, redirect: "manual" });
+
+  const headers = new Headers(request.headers);
+  // Strip hop-by-hop headers; undici rejects outbound `transfer-encoding: chunked`.
+  headers.delete("transfer-encoding");
+  headers.delete("content-length");
+  headers.delete("connection");
+  headers.set("accept-encoding", "application/json");
+  headers.set("host", new URL(siteUrl).host);
+  headers.set("x-forwarded-host", requestUrl.host);
+  headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+  headers.set("x-better-auth-forwarded-host", requestUrl.host);
+  headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
+
+  const init: RequestInit = {
+    headers,
+    method: request.method,
+    redirect: "manual",
+  };
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    const body = await request.arrayBuffer();
+    if (body.byteLength > 0) {
+      init.body = body;
+    }
+  }
+
+  return fetch(nextUrl, init);
 };
 
 const nextJsHandler = (siteUrl: string) => ({

--- a/src/react-start/index.test.ts
+++ b/src/react-start/index.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { convexBetterAuthReactStart } from "./index.js";
+
+const SITE_URL = "https://test.convex.site";
+const CONVEX_URL = "https://test.convex.cloud";
+
+const setup = () => {
+  const { handler } = convexBetterAuthReactStart({
+    convexUrl: CONVEX_URL,
+    convexSiteUrl: SITE_URL,
+  });
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response());
+  return { handler, fetchSpy };
+};
+
+const initOf = (
+  spy: ReturnType<typeof vi.spyOn>
+): RequestInit & { duplex?: string } =>
+  (spy.mock.calls[0]?.[1] as RequestInit & { duplex?: string }) ?? {};
+
+const headersOf = (spy: ReturnType<typeof vi.spyOn>): Headers =>
+  new Headers(initOf(spy).headers);
+
+describe("convexBetterAuthReactStart handler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips hop-by-hop headers from the forwarded request", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      {
+        method: "POST",
+        headers: {
+          "transfer-encoding": "chunked",
+          "content-length": "42",
+          connection: "keep-alive",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ email: "test@example.com" }),
+      }
+    );
+    await handler(request);
+    const headers = headersOf(fetchSpy);
+    expect(headers.get("transfer-encoding")).toBeNull();
+    expect(headers.get("content-length")).toBeNull();
+    expect(headers.get("connection")).toBeNull();
+  });
+
+  it("forwards to upstream URL preserving path and query", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email?foo=bar",
+      { method: "POST", body: "{}" }
+    );
+    await handler(request);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      `${SITE_URL}/api/auth/sign-in/email?foo=bar`
+    );
+  });
+
+  it("sets host and forwarding headers", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      { method: "POST", body: "{}" }
+    );
+    await handler(request);
+    const headers = headersOf(fetchSpy);
+    expect(headers.get("host")).toBe(new URL(SITE_URL).host);
+    expect(headers.get("x-forwarded-host")).toBe("app.example.com");
+    expect(headers.get("x-forwarded-proto")).toBe("https");
+    expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
+    expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
+  });
+
+  it("streams the request body with duplex: half", async () => {
+    const { handler, fetchSpy } = setup();
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      { method: "POST", body: JSON.stringify({ email: "test@example.com" }) }
+    );
+    await handler(request);
+    const init = initOf(fetchSpy);
+    expect(init.duplex).toBe("half");
+    expect(init.body).toBeDefined();
+  });
+});

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -63,6 +63,11 @@ const handler = (request: Request, opts: { convexSiteUrl: string }) => {
   const requestUrl = new URL(request.url);
   const nextUrl = `${opts.convexSiteUrl}${requestUrl.pathname}${requestUrl.search}`;
   const headers = new Headers(request.headers);
+  // Strip hop-by-hop headers inherited from the incoming request; undici
+  // rejects an outbound `transfer-encoding: chunked` header value.
+  headers.delete("transfer-encoding");
+  headers.delete("content-length");
+  headers.delete("connection");
   headers.set("accept-encoding", "application/json");
   headers.set("host", new URL(opts.convexSiteUrl).host);
   headers.set("x-forwarded-host", requestUrl.host);


### PR DESCRIPTION
- Strip `transfer-encoding`, `content-length`, `connection` from the inbound headers before forwarding in both the Next.js and React Start handlers. Inherited `transfer-encoding: chunked` was breaking outbound fetch via undici on Vercel Node lambdas.
- Next.js handler now buffers the body via `arrayBuffer()` (the previous `new Request(url, request)` re-introduced the bad headers); React Start keeps streaming with `duplex: "half"`.
- Mirrors the fix applied to `getToken` in #253.
- Diagnosed and proposed by @CipherSight.

Fixes #356