### PR TITLE
fix(react): drop non-simple params from fetchAccessToken (Hermes V1)

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -127,9 +127,12 @@ function useUseAuthFromBetterAuth(
           }
         }, [session, isSessionPending]);
         const fetchAccessToken = useCallback(
-          async ({
-            forceRefreshToken = false,
-          }: { forceRefreshToken?: boolean } = {}) => {
+          // Hermes V1 (RN 0.85 / Expo SDK 56) miscompiles async fns with
+          // non-simple params: await resolves to undefined, so isAuthenticated
+          // never flips true. Plain-identifier param keeps params simple.
+          // Drop when bundled Hermes ships facebook/hermes#2030/#2045/#2046.
+          async (opts?: { forceRefreshToken?: boolean }) => {
+            const forceRefreshToken = opts?.forceRefreshToken ?? false;
             if (cachedToken && !forceRefreshToken) {
               return cachedToken;
             }


### PR DESCRIPTION
After sign-in on Expo SDK 56 (RN `0.85.3`), `useConvexAuth().isAuthenticated` never flips to `true`. The session lands and `/convex/token` returns a JWT, but the bridge stays paused. Same on sign-up and sign-out.

Cause: Hermes V1 bug [facebook/hermes#1761](https://github.com/facebook/hermes/issues/1761). An async function with non-simple params (destructuring, defaults, or rest) miscompiles when the build preserves native async, so `await fn()` resolves to `undefined` while the body runs later. `fetchAccessToken` hit this, and convex-js reads the `undefined` as "no token" and silently de-auths.

Who hits it (preserve-async builds only, default pipelines are safe):
- Expo SDK 56 on `babel-preset-expo` below `56.0.6` (fixed upstream in `56.0.6` via [expo/expo#45601](https://github.com/expo/expo/pull/45601), now the default).
- Custom Metro configs, or bare RN `0.86+` with `unstable_preserveAsync`.

Fix: give `fetchAccessToken` simple params (plain options arg, `forceRefreshToken` read in the body, still async/await). Hermes then compiles it correctly on any pipeline.

The real fix is in Hermes ([facebook/hermes#2030](https://github.com/facebook/hermes/pull/2030), [#2045](https://github.com/facebook/hermes/pull/2045), [#2046](https://github.com/facebook/hermes/pull/2046), all open). Revert this once a bundled Hermes ships them.

Repro: [ramonclaudio/convex-better-auth-368-repro](https://github.com/ramonclaudio/convex-better-auth-368-repro). Build, typecheck, and lint clean. Tests unchanged.
