### PR TITLE
feat(docs): add per-page .md endpoint and Copy MD button

### DIFF
--- a/docs/app/(home)/[[...slug]]/page.tsx
+++ b/docs/app/(home)/[[...slug]]/page.tsx
@@ -1,3 +1,4 @@
+import { CopyMarkdownButton } from "@/components/copy-markdown";
 import { source } from "@/lib/source";
 import {
   DocsPage,
@@ -8,6 +9,14 @@ import {
 import { notFound } from "next/navigation";
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import { getMDXComponents } from "@/mdx-components";
+
+const BASE_PATH = "/better-auth";
+
+function mdUrlFor(pageUrl: string): string {
+  return pageUrl === "/"
+    ? `${BASE_PATH}/index.md`
+    : `${BASE_PATH}${pageUrl}.md`;
+}
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -24,6 +33,9 @@ export default async function Page(props: {
       full={page.data.full}
       tableOfContent={{ style: "clerk" }}
     >
+      <div className="flex justify-end">
+        <CopyMarkdownButton mdUrl={mdUrlFor(page.url)} />
+      </div>
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,26 @@
+import { getLLMText } from "@/lib/get-llm-text";
+import { source } from "@/lib/source";
+import { notFound } from "next/navigation";
+
+export const revalidate = false;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> }
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+  if (!page) notFound();
+
+  return new Response(await getLLMText(page), {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/docs/components/copy-markdown.tsx
+++ b/docs/components/copy-markdown.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import * as Popover from "@radix-ui/react-popover";
+import {
+  Check,
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  Link as LinkIcon,
+} from "lucide-react";
+import { useState } from "react";
+
+type Props = {
+  mdUrl: string;
+};
+
+export function CopyMarkdownButton({ mdUrl }: Props) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">(
+    "idle"
+  );
+  const [linkCopied, setLinkCopied] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const flash = (
+    setter: (v: boolean) => void,
+    onDone?: () => void
+  ) => {
+    setter(true);
+    window.setTimeout(() => {
+      setter(false);
+      onDone?.();
+    }, 1500);
+  };
+
+  const handleCopyMarkdown = async () => {
+    try {
+      const res = await fetch(mdUrl);
+      if (!res.ok) throw new Error(`Failed: ${res.status}`);
+      const text = await res.text();
+      await navigator.clipboard.writeText(text);
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 1500);
+    } catch {
+      setCopyState("error");
+      window.setTimeout(() => setCopyState("idle"), 2000);
+    }
+  };
+
+  const fullUrl = () =>
+    typeof window === "undefined"
+      ? mdUrl
+      : `${window.location.origin}${mdUrl}`;
+
+  const handleCopyLink = async () => {
+    await navigator.clipboard.writeText(fullUrl());
+    flash(setLinkCopied, () => setOpen(false));
+  };
+
+  const handleOpenLink = () => {
+    window.open(fullUrl(), "_blank", "noopener,noreferrer");
+    setOpen(false);
+  };
+
+  const copyLabel =
+    copyState === "copied"
+      ? "Copied"
+      : copyState === "error"
+        ? "Failed"
+        : "Copy MD";
+
+  return (
+    <div className="flex items-stretch overflow-hidden rounded-md border border-fd-border bg-fd-card text-fd-muted-foreground">
+      <button
+        type="button"
+        onClick={handleCopyMarkdown}
+        aria-label="Copy markdown to clipboard"
+        className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium transition hover:bg-fd-accent hover:text-fd-accent-foreground disabled:opacity-50"
+      >
+        {copyState === "copied" ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+        <span>{copyLabel}</span>
+      </button>
+      <div className="w-px bg-fd-border" aria-hidden="true" />
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            aria-label="Open markdown"
+            className="inline-flex items-center gap-1 px-2 py-1.5 text-xs font-medium transition hover:bg-fd-accent hover:text-fd-accent-foreground data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground"
+          >
+            <span>Open in</span>
+            <ChevronDown className="size-3.5" />
+          </button>
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            align="end"
+            sideOffset={6}
+            className="z-50 w-[200px] rounded-md border border-fd-border bg-fd-popover p-1 text-sm text-fd-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          >
+            <button
+              type="button"
+              onClick={handleCopyLink}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground"
+            >
+              {linkCopied ? (
+                <Check className="size-4" />
+              ) : (
+                <LinkIcon className="size-4" />
+              )}
+              <span>{linkCopied ? "Link copied" : "Copy markdown link"}</span>
+            </button>
+            <button
+              type="button"
+              onClick={handleOpenLink}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground"
+            >
+              <ExternalLink className="size-4" />
+              <span>Open in new tab</span>
+            </button>
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover.Root>
+    </div>
+  );
+}

--- a/docs/components/copy-markdown.tsx
+++ b/docs/components/copy-markdown.tsx
@@ -52,8 +52,12 @@ export function CopyMarkdownButton({ mdUrl }: Props) {
       : `${window.location.origin}${mdUrl}`;
 
   const handleCopyLink = async () => {
-    await navigator.clipboard.writeText(fullUrl());
-    flash(setLinkCopied, () => setOpen(false));
+    try {
+      await navigator.clipboard.writeText(fullUrl());
+      flash(setLinkCopied, () => setOpen(false));
+    } catch {
+      setOpen(false);
+    }
   };
 
   const handleOpenLink = () => {

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -12,10 +12,7 @@ export async function getLLMText(page: (typeof source)["$inferPage"]) {
 }
 
 function stripDropMarkers(text: string): string {
-  return text
-    .split("\n")
-    .filter((line) => !/^\s*​+\s*$/.test(line))
-    .join("\n");
+  return text.replace(/​+/g, "").replace(/^[ \t]+$/gm, "");
 }
 
 function collapseBlankLines(text: string): string {

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -1,0 +1,23 @@
+import { source } from "@/lib/source";
+
+export async function getLLMText(page: (typeof source)["$inferPage"]) {
+  const raw = await page.data.getText("processed");
+  const body = collapseBlankLines(stripDropMarkers(raw));
+  const description = page.data.description?.trim();
+
+  const header = `# ${page.data.title} (${page.url})`;
+  const intro = description ? `${header}\n\n${description}` : header;
+
+  return `${intro}\n\n${body}`;
+}
+
+function stripDropMarkers(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !/^\s*​+\s*$/.test(line))
+    .join("\n");
+}
+
+function collapseBlankLines(text: string): string {
+  return text.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -28,6 +28,14 @@ const config = {
       },
     ];
   },
+  rewrites: async () => {
+    return [
+      {
+        source: "/:path*.md",
+        destination: "/llms.mdx/:path*",
+      },
+    ];
+  },
 };
 
 export default withMDX(config);

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -4,12 +4,164 @@ import {
   frontmatterSchema,
   metaSchema,
 } from "fumadocs-mdx/config";
+import type { LLMsOptions } from "fumadocs-core/mdx-plugins";
 
-// You can customise Zod schemas for frontmatter and `meta.json` here
-// see https://fumadocs.vercel.app/docs/mdx/collections#define-docs
+const DROP_ELEMENTS = new Set([
+  "svg",
+  "path",
+  "defs",
+  "mask",
+  "rect",
+  "g",
+  "circle",
+  "polygon",
+  "polyline",
+  "line",
+  "ellipse",
+  "use",
+  "linearGradient",
+  "radialGradient",
+  "stop",
+  "title",
+  "CodeBlockTabsList",
+  "CodeBlockTabsTrigger",
+  "TabsList",
+  "TabsTrigger",
+]);
+
+const UNWRAP_ELEMENTS = new Set([
+  "div",
+  "span",
+  "Cards",
+  "Tabs",
+  "CodeBlockTabs",
+  "Steps",
+  "Step",
+  "Files",
+  "Folder",
+  "File",
+]);
+
+const CALLOUT_TYPE_LABELS: Record<string, string> = {
+  info: "Note",
+  note: "Note",
+  warn: "Warning",
+  warning: "Warning",
+  error: "Error",
+  success: "Success",
+  idea: "Tip",
+  tip: "Tip",
+};
+
+const DROP_PLACEHOLDER = "​";
+
+const llmsOptions: LLMsOptions = {
+  stringify(node, _parent, state, info) {
+    if (
+      node.type !== "mdxJsxFlowElement" &&
+      node.type !== "mdxJsxTextElement"
+    ) {
+      return undefined;
+    }
+    const name = node.name;
+    if (!name) return undefined;
+
+    if (DROP_ELEMENTS.has(name)) return DROP_PLACEHOLDER;
+
+    if (name === "Card") {
+      const href = readAttr(node, "href");
+      if (href) {
+        const label = readAttr(node, "title") ?? extractText(node) ?? href;
+        return `- [${label}](${href})\n`;
+      }
+      return renderChildren(node, state, info);
+    }
+
+    if (name === "Callout") {
+      return renderCallout(node, state, info);
+    }
+
+    if (name === "Tab" || name === "CodeBlockTab") {
+      return renderTab(node, state, info);
+    }
+
+    if (UNWRAP_ELEMENTS.has(name)) {
+      return renderChildren(node, state, info);
+    }
+
+    return undefined;
+  },
+};
+
+function renderChildren(node: any, state: any, info: any): string {
+  if (node.type === "mdxJsxTextElement") {
+    return state.containerPhrasing(node, info);
+  }
+  return state.containerFlow(node, info);
+}
+
+function renderCallout(node: any, state: any, info: any): string {
+  const type = readAttr(node, "type") ?? "note";
+  const title = readAttr(node, "title");
+  const typeLabel =
+    CALLOUT_TYPE_LABELS[type.toLowerCase()] ??
+    type.charAt(0).toUpperCase() + type.slice(1);
+  const heading = title ? `**${typeLabel}: ${title}**` : `**${typeLabel}**`;
+
+  const body = renderChildren(node, state, info).trim();
+  if (!body) return `> ${heading}\n`;
+  const quoted = body
+    .split("\n")
+    .map((line) => (line.length > 0 ? `> ${line}` : ">"))
+    .join("\n");
+  return `> ${heading}\n>\n${quoted}\n`;
+}
+
+function renderTab(node: any, state: any, info: any): string {
+  const value = readAttr(node, "value");
+  const body = renderChildren(node, state, info).trim();
+  if (!value) return body ? `${body}\n` : DROP_PLACEHOLDER;
+  if (!body) return `**${value}**\n`;
+  return `**${value}**\n\n${body}\n`;
+}
+
+function readAttr(node: any, name: string): string | undefined {
+  const attr = node.attributes?.find(
+    (a: any) => a.type === "mdxJsxAttribute" && a.name === name
+  );
+  if (!attr) return undefined;
+  const v = attr.value;
+  if (typeof v === "string") return v;
+  if (v && typeof v === "object" && typeof v.value === "string") return v.value;
+  return undefined;
+}
+
+function extractText(node: any): string | undefined {
+  const parts: string[] = [];
+  const walk = (n: any, skip: boolean) => {
+    if (!n) return;
+    if (n.type === "text" && typeof n.value === "string" && !skip) {
+      parts.push(n.value);
+    }
+    if (Array.isArray(n.children)) {
+      const isDrop =
+        (n.type === "mdxJsxFlowElement" || n.type === "mdxJsxTextElement") &&
+        typeof n.name === "string" &&
+        DROP_ELEMENTS.has(n.name);
+      n.children.forEach((c: any) => walk(c, skip || isDrop));
+    }
+  };
+  walk(node, false);
+  const text = parts.join(" ").replace(/\s+/g, " ").trim();
+  return text.length > 0 ? text : undefined;
+}
+
 export const docs = defineDocs({
   docs: {
     schema: frontmatterSchema,
+    postprocess: {
+      includeProcessedMarkdown: llmsOptions,
+    },
   },
   meta: {
     schema: metaSchema,


### PR DESCRIPTION
 Closes #378

  Appending `.md` to any docs URL returns the page as markdown. Useful for piping docs into Claude/ChatGPT/Cursor without scraping HTML.

  /better-auth/basic-usage/authorization      → renders normally
  /better-auth/basic-usage/authorization.md   → raw markdown

  Also added a Copy MD button + Open in ▾ dropdown (Copy markdown link / Open in new tab) in the top-right of every docs page, styled with
  Fumadocs theme tokens.

  **Changes:**
  - `source.config.ts`: enabled `includeProcessedMarkdown` with a custom stringify so the output is actual markdown. Strips inline SVGs,
  unwraps `<Cards>` / `<Callout>` / `<CodeBlockTabs>` / fd-step divs, renders Callouts as blockquotes, keeps tab labels.
  - `lib/get-llm-text.ts`: formats `# Title (/url)` + description + body
  - `app/llms.mdx/[[...slug]]/route.ts`: route handler. Statically prerendered for every page, with `Access-Control-Allow-Origin: *` and a
  1h browser / 24h CDN cache.
  - `next.config.mjs`: rewrite `/:path*.md` → `/llms.mdx/:path*`
  - `components/copy-markdown.tsx`: Copy button + Radix popover dropdown. Uses Fumadocs UI's transitive deps so no new packages.

  Tested locally across all 25 docs pages, regular site still renders, unknown paths 404, build clean.

  Skipped `llms.txt` / `llms-full.txt` to keep the PR focused — happy to follow up in a separate one if useful.