### PR TITLE
fix cross-domain client plugin types

### DIFF
--- a/src/plugins/cross-domain/client.test.ts
+++ b/src/plugins/cross-domain/client.test.ts
@@ -138,12 +138,12 @@ describe("crossDomainClient", () => {
       notify: () => {},
       atoms: { session: { set: () => {}, get: () => ({}) } },
     };
-    return plugin.getActions({} as any, mockStore as any);
+    return plugin.getActions({} as any, mockStore as any, undefined);
   }
 
   function getOnSuccessHook() {
     const plugin = crossDomainClient({ storage: mockStorage });
-    return plugin.fetchPlugins[0].hooks!.onSuccess!;
+    return plugin.fetchPlugins![0].hooks!.onSuccess!;
   }
 
   function getOnSuccessHookWithStore() {
@@ -154,8 +154,8 @@ describe("crossDomainClient", () => {
       atoms: { session: { set: () => {}, get: () => ({}) } },
     };
     // getActions sets the internal store reference
-    plugin.getActions({} as any, mockStore as any);
-    return { onSuccess: plugin.fetchPlugins[0].hooks!.onSuccess!, notify };
+    plugin.getActions({} as any, mockStore as any, undefined);
+    return { onSuccess: plugin.fetchPlugins![0].hooks!.onSuccess!, notify };
   }
 
   describe("getSessionData", () => {

--- a/src/plugins/cross-domain/client.ts
+++ b/src/plugins/cross-domain/client.ts
@@ -1,4 +1,4 @@
-import type { BetterAuthClientPlugin, ClientStore } from "better-auth";
+import type { BetterAuthClientPlugin, ClientStore } from "better-auth/client";
 import { parseSetCookieHeader } from "better-auth/cookies";
 import type { BetterFetchOption } from "@better-fetch/fetch";
 import type { crossDomain } from "./index.js";
@@ -8,6 +8,22 @@ interface StoredCookie {
   value: string;
   expires: string | null;
 }
+
+type CrossDomainActions = {
+  getCookie: () => string;
+  updateSession: () => void;
+  getSessionData: () => Record<string, unknown> | null;
+};
+
+type CrossDomainClientPlugin = Omit<
+  BetterAuthClientPlugin,
+  "$InferServerPlugin" | "getActions"
+> & {
+  $InferServerPlugin: ReturnType<typeof crossDomain>;
+  getActions: (
+    ...args: Parameters<NonNullable<BetterAuthClientPlugin["getActions"]>>
+  ) => CrossDomainActions;
+};
 
 export function getSetCookie(header: string, prevCookie?: string) {
   const parsed = parseSetCookieHeader(header);
@@ -63,7 +79,7 @@ export const crossDomainClient = (
     storagePrefix?: string;
     disableCache?: boolean;
   } = {}
-) => {
+): CrossDomainClientPlugin => {
   let store: ClientStore | null = null;
   const cookieName = `${opts?.storagePrefix || "better-auth"}_cookie`;
   const localCacheName = `${opts?.storagePrefix || "better-auth"}_session_data`;
@@ -247,5 +263,5 @@ export const crossDomainClient = (
         },
       },
     ],
-  } satisfies BetterAuthClientPlugin;
+  };
 };

--- a/src/plugins/cross-domain/client.types.test.ts
+++ b/src/plugins/cross-domain/client.types.test.ts
@@ -1,0 +1,19 @@
+import { adminClient } from "better-auth/client/plugins";
+import { createAuthClient } from "better-auth/react";
+import { expectTypeOf, it } from "vitest";
+import { convexClient } from "../convex/client.js";
+import { crossDomainClient } from "./client.js";
+
+const storage = {
+  getItem: () => null,
+  setItem: () => undefined,
+};
+
+it("composes with Better Auth client plugins and infers cross-domain actions", () => {
+  const authClient = createAuthClient({
+    baseURL: "http://localhost:3000",
+    plugins: [convexClient(), crossDomainClient({ storage }), adminClient()],
+  });
+
+  expectTypeOf(authClient.getCookie).toEqualTypeOf<() => string>();
+});


### PR DESCRIPTION
🐛 Fixes #195

🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 `/tmp/convex-ba-repro-j7CbNK npm run typecheck` failed before patch with `better-auth@1.6.18`: `crossDomainClient()` rejected as `BetterAuthClientPlugin`; `getCookie` missing | ➖ N/A |
| Verified | 🟢 `npm run build`; `npm run test`; `npm run lint`; `npm run typecheck`; repacked tarball repro passed against `better-auth@1.6.18` | ➖ N/A |

**✅ Outcome**

`crossDomainClient()` now composes with current Better Auth 1.6.x client plugins and keeps inferred actions such as `getCookie`.

**⚠️ Caveat**

This does not fix Better Auth's broader inferred-client type explosion/OOM class. It fixes the `@convex-dev/better-auth` compatibility bug that made the supported peer range lie.

**🏗️ Design**

The fix is a type-boundary repair on `crossDomainClient()`: use Better Auth's current client plugin contract, keep the current `getActions` parameter shape, and preserve the concrete cross-domain server plugin/actions inference. Runtime object shape is unchanged.

**🧪 Verified**

- `npm run build`
- `npx vitest run --typecheck src/plugins/cross-domain/client.types.test.ts src/plugins/cross-domain/client.test.ts`
- `npm run test`
- `npm run lint`
- `npm run typecheck`
- `/tmp/convex-ba-repro-j7CbNK npm run typecheck` with repacked package + `better-auth@1.6.18`
- `autoreview --mode local`: clean, no accepted/actionable findings
