### PR TITLE
Fix unbounded count/findMany pagination looping forever past 200 rows

### DIFF
--- a/src/client/adapter-pagination.test.ts
+++ b/src/client/adapter-pagination.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="vite/client" />
+
+import { describe, expect, it } from "vitest";
+import { convexTest } from "convex-test";
+import type { BetterAuthOptions } from "better-auth";
+import { api } from "../component/_generated/api.js";
+import schema from "../component/testProfiles/schema.profile-plugin-table.js";
+import { createClient } from "./index.js";
+import type { DataModel } from "../component/_generated/dataModel.js";
+
+/**
+ * Regression test for get-convex/better-auth#392: count() is an unlimited
+ * paginated findMany and must terminate over result sets larger than the
+ * 200-row page size. The runQuery cap turns a non-terminating loop into a
+ * fast, clear failure instead of running to the function's wall-clock limit,
+ * so the test never hangs CI when the bug regresses.
+ */
+describe("count() pagination", () => {
+  it("terminates over more than 200 rows", async () => {
+    const t = convexTest(schema, import.meta.glob("../component/**/*.*s"));
+    let paginatedQueries = 0;
+    const ctx = {
+      runMutation: t.mutation.bind(t),
+      runQuery: async (...args: any[]) => {
+        paginatedQueries += 1;
+        if (paginatedQueries > 50) {
+          throw new Error(
+            `count() issued ${paginatedQueries} paginated queries without terminating (infinite pagination loop)`
+          );
+        }
+        return (t.query as any)(...args);
+      },
+    } as any;
+
+    // `.adapter(ctx)` returns a Better Auth adapter factory; resolve it with
+    // options (the Convex adapter generates ids itself, so empty options are
+    // enough to expose the core `user` model).
+    const adapter = createClient<DataModel>({ adapter: api.adapter } as any, {
+      verbose: false,
+    }).adapter(ctx)({} as BetterAuthOptions);
+
+    for (let i = 0; i < 201; i++) {
+      await adapter.create({
+        model: "user",
+        data: { name: `foo${i}`, email: `foo${i}@bar.com` },
+      });
+    }
+    paginatedQueries = 0; // count only the pagination queries
+    expect(await adapter.count({ model: "user" })).toBe(201);
+  });
+});

--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -66,17 +66,31 @@ const handlePagination = async (
   };
 
   do {
+    const cursorBeforePage = state.cursor;
     const result = await next({
       paginationOpts: {
+        // Subtract collected rows so the last page doesn't over-fetch past a
+        // caller limit. No limit means an unbounded budget (Infinity, not 200,
+        // or collecting 200 makes numItems 0 and the cursor never advances; #392).
         numItems: Math.min(
           numItems ?? 200,
-          (limit ?? 200) - state.docs.length,
+          limit !== undefined ? limit - state.docs.length : Infinity,
           200
         ),
         cursor: state.cursor,
       },
     });
     onResult(result);
+    // A page that returns nothing and doesn't advance the cursor while !isDone
+    // can never terminate; fail loudly instead of looping forever.
+    const advanced = state.cursor !== cursorBeforePage;
+    const produced =
+      (result.page?.length ?? 0) > 0 || (result.count ?? 0) > 0;
+    if (!state.isDone && !advanced && !produced) {
+      throw new Error(
+        "handlePagination made no forward progress; aborting to avoid an infinite pagination loop"
+      );
+    }
   } while (!state.isDone);
   return state;
 };


### PR DESCRIPTION
Fixes #392.

- `count()` / unlimited `findMany` looped forever past 200 rows: with no limit, `numItems` collapsed to 0 after the first page and the cursor stopped advancing.
- Page at the full 200 when there is no caller limit; keep the over-fetch trim for limited queries.
- Add a forward-progress guard so a non-advancing page throws instead of hanging.

Reported and diagnosed by @getwig.