### PR TITLE
fix(react): preserve createAuthClient session types in AuthClient

### DIFF
--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -8,8 +8,8 @@ import {
   useQuery,
 } from "convex/react";
 import type { FunctionReference } from "convex/server";
-import type { BetterAuthClientPlugin } from "better-auth";
-import type { createAuthClient } from "better-auth/react";
+import type { BetterAuthClientPlugin, BetterAuthClientOptions } from "better-auth";
+import type { ReactAuthClient } from "better-auth/react";
 import type {
   convexClient,
   crossDomainClient,
@@ -24,18 +24,21 @@ type PluginsWithCrossDomain = (
   | BetterAuthClientPlugin
 )[];
 type PluginsWithoutCrossDomain = (ConvexClient | BetterAuthClientPlugin)[];
+type SupportedClientOptions = BetterAuthClientOptions & {
+  plugins?: PluginsWithCrossDomain | PluginsWithoutCrossDomain;
+};
 type AuthClientWithPlugins<
   Plugins extends PluginsWithCrossDomain | PluginsWithoutCrossDomain,
-> = ReturnType<
-  typeof createAuthClient<
-    BetterAuthClientPlugin & {
-      plugins: Plugins;
-    }
-  >
->;
-export type AuthClient =
-  | AuthClientWithPlugins<PluginsWithCrossDomain>
-  | AuthClientWithPlugins<PluginsWithoutCrossDomain>;
+> = ReactAuthClient<{
+  plugins: Plugins;
+}>;
+/** @internal Auth client shape used by ConvexBetterAuthProvider internals. */
+type InternalAuthClient = ReactAuthClient<{
+  plugins: [ConvexClient];
+}>;
+export type AuthClient<
+  Option extends SupportedClientOptions = SupportedClientOptions,
+> = ReactAuthClient<Option>;
 
 // Until we can import from our own entry points (requires TypeScript 4.7),
 // just describe the interface enough to help users pass the right type.
@@ -50,7 +53,9 @@ type IConvexReactClient = {
  *
  * @public
  */
-export function ConvexBetterAuthProvider({
+export function ConvexBetterAuthProvider<
+  Option extends SupportedClientOptions,
+>({
   children,
   client,
   authClient,
@@ -58,10 +63,13 @@ export function ConvexBetterAuthProvider({
 }: {
   children: ReactNode;
   client: IConvexReactClient;
-  authClient: AuthClient;
+  authClient: ReactAuthClient<Option>;
   initialToken?: string | null;
 }) {
-  const useBetterAuth = useUseAuthFromBetterAuth(authClient, initialToken);
+  const useBetterAuth = useUseAuthFromBetterAuth(
+    authClient as unknown as InternalAuthClient,
+    initialToken,
+  );
   useEffect(() => {
     (async () => {
       if (typeof window === "undefined" || !window.location?.href) {
@@ -71,7 +79,7 @@ export function ConvexBetterAuthProvider({
       const token = url.searchParams.get("ott");
       if (token) {
         const authClientWithCrossDomain =
-          authClient as AuthClientWithPlugins<PluginsWithCrossDomain>;
+          authClient as unknown as AuthClientWithPlugins<PluginsWithCrossDomain>;
         url.searchParams.delete("ott");
         window.history.replaceState({}, "", url);
         const result =
@@ -80,7 +88,7 @@ export function ConvexBetterAuthProvider({
           });
         const session = result.data?.session;
         if (session) {
-          await authClient.getSession({
+          await (authClient as unknown as InternalAuthClient).getSession({
             fetchOptions: {
               headers: {
                 Authorization: `Bearer ${session.token}`,
@@ -102,7 +110,7 @@ export function ConvexBetterAuthProvider({
 let initialTokenUsed = false;
 
 function useUseAuthFromBetterAuth(
-  authClient: AuthClient,
+  authClient: InternalAuthClient,
   initialToken?: string | null
 ) {
   const [cachedToken, setCachedToken] = useState<string | null>(
@@ -256,7 +264,9 @@ const UserSubscription = ({
  * The component provides a query for this via `export const { getAuthUser } = authComponent.clientApi()`.
  * @param props.isAuthError - Function to check if the error is auth related.
  */
-export const AuthBoundary = ({
+export const AuthBoundary = <
+  Option extends SupportedClientOptions,
+>({
   children,
   /**
    * The function to call when the user is unauthenticated. Typically a redirect
@@ -282,7 +292,7 @@ export const AuthBoundary = ({
   isAuthError,
 }: PropsWithChildren<{
   onUnauth: () => void | Promise<void>;
-  authClient: AuthClient;
+  authClient: ReactAuthClient<Option>;
   renderFallback?: () => React.ReactNode;
   getAuthUserFn: FunctionReference<"query", "public", EmptyObject>;
   isAuthError: (error: unknown) => boolean;
@@ -290,7 +300,7 @@ export const AuthBoundary = ({
   const { isAuthenticated, isLoading } = useConvexAuth();
   const handleUnauth = useCallback(async () => {
     // Auth request that will clear cookies if session is invalid
-    await authClient.getSession();
+    await (authClient as unknown as InternalAuthClient).getSession();
     await onUnauth();
   }, [onUnauth]);
 

--- a/src/react/index.types.test.ts
+++ b/src/react/index.types.test.ts
@@ -1,0 +1,21 @@
+import { anonymousClient } from "better-auth/client/plugins";
+import { createAuthClient } from "better-auth/react";
+import { expectTypeOf, it } from "vitest";
+import { convexClient } from "../plugins/convex/client.js";
+import type { AuthClient } from "./index.js";
+
+it("accepts createAuthClient with convexClient plugin", () => {
+  const authClient = createAuthClient({
+    plugins: [convexClient()],
+  });
+
+  expectTypeOf(authClient).toMatchTypeOf<AuthClient>();
+});
+
+it("accepts createAuthClient with convexClient and anonymousClient plugins", () => {
+  const authClient = createAuthClient({
+    plugins: [anonymousClient(), convexClient()],
+  });
+
+  expectTypeOf(authClient).toMatchTypeOf<AuthClient>();
+});


### PR DESCRIPTION
## Summary

Fixes #393.

- Replaces the broken `AuthClient` alias that passed `BetterAuthClientPlugin` into `createAuthClient`'s options generic (which inferred `useSession().data` as `never` with `better-auth@1.6.20+`)
- Uses `ReactAuthClient` with proper `BetterAuthClientOptions` instead
- Makes `ConvexBetterAuthProvider` and `AuthBoundary` generic over the caller's client options so plugin tuples from `createAuthClient({ plugins: [convexClient()] })` are preserved
- Adds regression type tests for `convexClient()` and `anonymousClient()` + `convexClient()` compositions

## Root cause

`better-auth@1.6.20` changed `createAuthClient` to return `ReactAuthClient<Option>`. The exported `AuthClient` type was:

```ts
ReturnType<typeof createAuthClient<BetterAuthClientPlugin & { plugins: Plugins }>>
```

Because `BetterAuthClientPlugin` is a plugin interface—not client options—session inference failed and `useSession().data` resolved to `never`, rejecting valid clients at call sites like `ConvexBetterAuthProvider`.

## Test plan

- [x] `npm run build`
- [x] `npm run test` (includes new `src/react/index.types.test.ts` type tests)
- [x] Verified against a consuming app using `better-auth@1.6.22` + `@convex-dev/better-auth@0.12.5` (`tsc --noEmit` passes for `ConvexBetterAuthProvider authClient={authClient}`)


Made with [Cursor](https://cursor.com)