### PR TITLE
fix: emit v.id() for Better Auth foreign key fields in schema generator

### DIFF
--- a/src/client/create-schema.test.ts
+++ b/src/client/create-schema.test.ts
@@ -9,7 +9,7 @@ const tableBlock = (code: string, table: string): string => {
   const start = code.indexOf(marker);
   expect(start, `table "${table}"`).toBeGreaterThanOrEqual(0);
   const searchFrom = start + marker.length;
-  const nextTable = code.slice(searchFrom).search(/\n  \w+: defineTable\(\{/);
+  const nextTable = code.slice(searchFrom).search(/\n {2}\w+: defineTable\(\{/);
   const end =
     nextTable === -1 ? code.indexOf("\n};", start) : searchFrom + nextTable;
   expect(end, `end of table "${table}"`).toBeGreaterThan(start);

--- a/src/client/create-schema.test.ts
+++ b/src/client/create-schema.test.ts
@@ -4,16 +4,28 @@ import { organization } from "better-auth/plugins";
 import { describe, expect, it } from "vitest";
 import { createSchema } from "./create-schema.js";
 
+const tableBlock = (code: string, table: string): string => {
+  const marker = `  ${table}: defineTable({`;
+  const start = code.indexOf(marker);
+  expect(start, `table "${table}"`).toBeGreaterThanOrEqual(0);
+  const searchFrom = start + marker.length;
+  const nextTable = code.slice(searchFrom).search(/\n  \w+: defineTable\(\{/);
+  const end =
+    nextTable === -1 ? code.indexOf("\n};", start) : searchFrom + nextTable;
+  expect(end, `end of table "${table}"`).toBeGreaterThan(start);
+  return code.slice(start, end);
+};
+
 describe("createSchema", () => {
   it("emits v.id() for core FK fields", async () => {
     const tables = getAuthTables({});
     const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
 
-    expect(code).toMatch(/session: defineTable[\s\S]*userId: v\.id\("user"\)/);
-    expect(code).toMatch(/account: defineTable[\s\S]*userId: v\.id\("user"\)/);
-    expect(code).toContain("accountId: v.string()");
-    expect(code).toContain("providerId: v.string()");
-    expect(code).toContain("token: v.string()");
+    expect(tableBlock(code, "session")).toContain('userId: v.id("user")');
+    expect(tableBlock(code, "account")).toContain('userId: v.id("user")');
+    expect(tableBlock(code, "account")).toContain("accountId: v.string()");
+    expect(tableBlock(code, "account")).toContain("providerId: v.string()");
+    expect(tableBlock(code, "session")).toContain("token: v.string()");
   });
 
   it("keeps user.userId as v.string() without references metadata", async () => {
@@ -26,8 +38,8 @@ describe("createSchema", () => {
     });
     const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
 
-    expect(code).toMatch(
-      /user: defineTable[\s\S]*userId: v\.optional\(v\.union\(v\.null\(\), v\.string\(\)\)\)/
+    expect(tableBlock(code, "user")).toContain(
+      "userId: v.optional(v.union(v.null(), v.string()))"
     );
   });
 
@@ -37,17 +49,15 @@ describe("createSchema", () => {
     });
     const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
 
-    expect(code).toMatch(
-      /member: defineTable[\s\S]*organizationId: v\.id\("organization"\)/
+    expect(tableBlock(code, "member")).toContain(
+      'organizationId: v.id("organization")'
     );
-    expect(code).toMatch(/member: defineTable[\s\S]*userId: v\.id\("user"\)/);
-    expect(code).toMatch(
-      /invitation: defineTable[\s\S]*organizationId: v\.id\("organization"\)/
+    expect(tableBlock(code, "member")).toContain('userId: v.id("user")');
+    expect(tableBlock(code, "invitation")).toContain(
+      'organizationId: v.id("organization")'
     );
-    expect(code).toMatch(
-      /invitation: defineTable[\s\S]*inviterId: v\.id\("user"\)/
-    );
-    expect(code).toContain(
+    expect(tableBlock(code, "invitation")).toContain('inviterId: v.id("user")');
+    expect(tableBlock(code, "session")).toContain(
       "activeOrganizationId: v.optional(v.union(v.null(), v.string()))"
     );
   });
@@ -58,7 +68,8 @@ describe("createSchema", () => {
     });
     const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
 
-    expect(code).toContain('userId: v.id("users")');
+    expect(tableBlock(code, "session")).toContain('userId: v.id("users")');
+    expect(tableBlock(code, "account")).toContain('userId: v.id("users")');
     expect(code).toMatch(/users: defineTable/);
   });
 
@@ -80,7 +91,7 @@ describe("createSchema", () => {
     const tables = getAuthTables({ plugins: [plugin] });
     const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
 
-    expect(code).toContain("ownerId: v.string()");
+    expect(tableBlock(code, "widget")).toContain("ownerId: v.string()");
   });
 
   it("wraps optional FKs with v.optional(v.union(v.null(), v.id(...)))", async () => {
@@ -101,7 +112,7 @@ describe("createSchema", () => {
     const tables = getAuthTables({ plugins: [plugin] });
     const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
 
-    expect(code).toContain(
+    expect(tableBlock(code, "optionalRef")).toContain(
       'userId: v.optional(v.union(v.null(), v.id("user")))'
     );
   });

--- a/src/client/create-schema.test.ts
+++ b/src/client/create-schema.test.ts
@@ -1,0 +1,108 @@
+import type { BetterAuthPlugin } from "better-auth";
+import { getAuthTables } from "@better-auth/core/db";
+import { organization } from "better-auth/plugins";
+import { describe, expect, it } from "vitest";
+import { createSchema } from "./create-schema.js";
+
+describe("createSchema", () => {
+  it("emits v.id() for core FK fields", async () => {
+    const tables = getAuthTables({});
+    const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
+
+    expect(code).toMatch(/session: defineTable[\s\S]*userId: v\.id\("user"\)/);
+    expect(code).toMatch(/account: defineTable[\s\S]*userId: v\.id\("user"\)/);
+    expect(code).toContain("accountId: v.string()");
+    expect(code).toContain("providerId: v.string()");
+    expect(code).toContain("token: v.string()");
+  });
+
+  it("keeps user.userId as v.string() without references metadata", async () => {
+    const tables = getAuthTables({
+      user: {
+        additionalFields: {
+          userId: { type: "string", required: false },
+        },
+      },
+    });
+    const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
+
+    expect(code).toMatch(
+      /user: defineTable[\s\S]*userId: v\.optional\(v\.union\(v\.null\(\), v\.string\(\)\)\)/
+    );
+  });
+
+  it("emits v.id() for organization plugin FK fields", async () => {
+    const tables = getAuthTables({
+      plugins: [organization()],
+    });
+    const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
+
+    expect(code).toMatch(
+      /member: defineTable[\s\S]*organizationId: v\.id\("organization"\)/
+    );
+    expect(code).toMatch(/member: defineTable[\s\S]*userId: v\.id\("user"\)/);
+    expect(code).toMatch(
+      /invitation: defineTable[\s\S]*organizationId: v\.id\("organization"\)/
+    );
+    expect(code).toMatch(
+      /invitation: defineTable[\s\S]*inviterId: v\.id\("user"\)/
+    );
+    expect(code).toContain(
+      "activeOrganizationId: v.optional(v.union(v.null(), v.string()))"
+    );
+  });
+
+  it("uses renamed modelName in v.id()", async () => {
+    const tables = getAuthTables({
+      user: { modelName: "users" },
+    });
+    const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
+
+    expect(code).toContain('userId: v.id("users")');
+    expect(code).toMatch(/users: defineTable/);
+  });
+
+  it("keeps v.string() when referenced table is absent from schema", async () => {
+    const plugin = {
+      id: "external-ref-test",
+      schema: {
+        widget: {
+          fields: {
+            ownerId: {
+              type: "string",
+              required: true,
+              references: { field: "id", model: "externalAppUser" },
+            },
+          },
+        },
+      },
+    } satisfies BetterAuthPlugin;
+    const tables = getAuthTables({ plugins: [plugin] });
+    const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
+
+    expect(code).toContain("ownerId: v.string()");
+  });
+
+  it("wraps optional FKs with v.optional(v.union(v.null(), v.id(...)))", async () => {
+    const plugin = {
+      id: "optional-fk-test",
+      schema: {
+        optionalRef: {
+          fields: {
+            userId: {
+              type: "string",
+              required: false,
+              references: { field: "id", model: "user" },
+            },
+          },
+        },
+      },
+    } satisfies BetterAuthPlugin;
+    const tables = getAuthTables({ plugins: [plugin] });
+    const { code } = await createSchema({ tables, file: "generatedSchema.ts" });
+
+    expect(code).toContain(
+      'userId: v.optional(v.union(v.null(), v.id("user")))'
+    );
+  });
+});

--- a/src/client/create-schema.ts
+++ b/src/client/create-schema.ts
@@ -50,6 +50,58 @@ const specialFields = (tables: BetterAuthDBSchema) =>
       )
   );
 
+const resolveReferencedTableName = (
+  refModel: string,
+  tables: BetterAuthDBSchema
+): string | null => {
+  const byKey = tables[refModel];
+  if (byKey) {
+    return byKey.modelName;
+  }
+  const byModelName = Object.values(tables).find(
+    (table) => table.modelName === refModel
+  );
+  return byModelName?.modelName ?? null;
+};
+
+const getFieldValidator = (
+  field: DBFieldAttribute,
+  tables: BetterAuthDBSchema
+): string => {
+  if (
+    field.type === "string" &&
+    field.references?.field === "id" &&
+    field.references.model
+  ) {
+    const tableName = resolveReferencedTableName(
+      field.references.model,
+      tables
+    );
+    if (tableName) {
+      return `v.id("${tableName}")`;
+    }
+  }
+
+  const type = field.type as
+    | "string"
+    | "number"
+    | "boolean"
+    | "date"
+    | "json"
+    | `${"string" | "number"}[]`;
+
+  const typeMap: Record<typeof type, string> = {
+    string: `v.string()`,
+    boolean: `v.boolean()`,
+    number: `v.number()`,
+    date: `v.number()`,
+    json: `v.string()`,
+    "number[]": `v.array(v.number())`,
+    "string[]": `v.array(v.string())`,
+  } as const;
+  return typeMap[type];
+};
+
 const mergedIndexFields = (tables: BetterAuthDBSchema) =>
   Object.fromEntries(
     Object.entries(tables).map(([key, table]) => {
@@ -142,27 +194,6 @@ export const tables = {
       Object.entries(table.fields).filter(([key]) => key !== "id")
     );
 
-    function getType(name: string, field: DBFieldAttribute) {
-      const type = field.type as
-        | "string"
-        | "number"
-        | "boolean"
-        | "date"
-        | "json"
-        | `${"string" | "number"}[]`;
-
-      const typeMap: Record<typeof type, string> = {
-        string: `v.string()`,
-        boolean: `v.boolean()`,
-        number: `v.number()`,
-        date: `v.number()`,
-        json: `v.string()`,
-        "number[]": `v.array(v.number())`,
-        "string[]": `v.array(v.string())`,
-      } as const;
-      return typeMap[type];
-    }
-
     const indexes =
       mergedIndexFields(tables)[
         tableKey as keyof typeof mergedIndexFields
@@ -176,7 +207,7 @@ export const tables = {
 ${Object.keys(fields)
   .map((field) => {
     const attr = fields[field]!;
-    const type = getType(field, attr as DBFieldAttribute);
+    const type = getFieldValidator(attr as DBFieldAttribute, tables);
     const optional = (fieldSchema: string) =>
       attr.required
         ? fieldSchema


### PR DESCRIPTION
## Summary

- `createSchema()` now emits `v.id("tableName")` for fields where Better Auth provides `references: { field: "id", model: "…" }` and the referenced table exists in the generated schema
- Non-FK strings unchanged (`user.userId`, OAuth ids, tokens, `activeOrganizationId`)
- Optional FKs correctly wrapped with `v.optional(v.union(v.null(), v.id(...)))`
- Adds snapshot-style tests for core tables, org plugin, renamed models, absent refs, and optional FKs

## Problem

When running `npx auth generate` in a local-install Better Auth component, the generated Convex schema used `v.string()` for every Better Auth `"string"` field — including documented foreign keys. Better Auth already exposes `field.references` (used for index generation); the Convex generator read it for indexes but not for validator emission.

Consumers had to manually re-declare entire tables in `schema.ts` to get type-safe `v.id("tableName")` validators.

## Related issues

- Complements [#108](https://github.com/get-convex/better-auth/issues/108) (branded validators)
- Cross-component references in the main app schema still require `v.string()` per [#112](https://github.com/get-convex/better-auth/issues/112) / [#69](https://github.com/get-convex/better-auth/issues/69) — out of scope for this PR

## Not covered (follow-up)

`session.activeOrganizationId` remains `v.string()` because the org plugin defines it without `references` metadata. Options: manual override, name-based heuristic, or upstream Better Auth org plugin change.

## Test plan

- [x] `npx vitest run src/client/create-schema.test.ts` — 6 tests pass
- [x] `npx vitest run src/client/` — all client tests pass


Made with [Cursor](https://cursor.com)