### PR TITLE
Support case-insensitive string filters, findMany offset, and mixed AND/OR where clauses

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -129,7 +129,10 @@ const findIndex = (
         ["lt", "lte", "gt", "gte", "eq", "in", "not_in"].includes(
           w.operator
         )) &&
-      w.field !== "_id"
+      w.field !== "_id" &&
+      // Convex index lookups are case-sensitive; insensitive clauses are
+      // applied as static filters instead.
+      w.mode !== "insensitive"
     );
   });
   if (!where?.length && !args.sortBy) {
@@ -340,17 +343,28 @@ const filterByWhere = <
       return val > wVal;
     };
     const filter = (w: Infer<typeof adapterWhereValidator>) => {
+      // Case-insensitive matching folds both sides to lowercase. Range
+      // operators (lt/lte/gt/gte) stay case-sensitive; paginate rejects
+      // insensitive mode for those.
+      const fold = <V>(val: V): V =>
+        w.mode === "insensitive" && typeof val === "string"
+          ? (val.toLowerCase() as V)
+          : val;
       switch (w.operator) {
         case undefined:
         case "eq": {
-          return value === w.value;
+          return fold(value) === fold(w.value);
         }
         case "in": {
-          return Array.isArray(w.value) && (w.value as any[]).includes(value);
+          return (
+            Array.isArray(w.value) &&
+            (w.value as any[]).map(fold).includes(fold(value))
+          );
         }
         case "not_in": {
           const result =
-            Array.isArray(w.value) && !(w.value as any[]).includes(value);
+            Array.isArray(w.value) &&
+            !(w.value as any[]).map(fold).includes(fold(value));
           return result;
         }
         case "lt": {
@@ -366,18 +380,25 @@ const filterByWhere = <
           return value === w.value || isGreaterThan(value, w.value);
         }
         case "ne": {
-          return value !== w.value;
+          return fold(value) !== fold(w.value);
         }
         case "contains": {
-          return typeof value === "string" && value.includes(w.value as string);
+          return (
+            typeof value === "string" &&
+            fold(value).includes(fold(w.value) as string)
+          );
         }
         case "starts_with": {
           return (
-            typeof value === "string" && value.startsWith(w.value as string)
+            typeof value === "string" &&
+            fold(value).startsWith(fold(w.value) as string)
           );
         }
         case "ends_with": {
-          return typeof value === "string" && value.endsWith(w.value as string);
+          return (
+            typeof value === "string" &&
+            fold(value).endsWith(fold(w.value) as string)
+          );
         }
       }
     };
@@ -452,12 +473,14 @@ const generateQuery = (
       doc,
       args.where,
       // Index used for all eq and range clauses, apply remaining clauses
-      // incompatible with Convex statically.
+      // incompatible with Convex statically. Insensitive clauses are always
+      // excluded from index selection, so they must be applied here too.
       (w) =>
-        w.operator &&
-        ["contains", "starts_with", "ends_with", "ne", "not_in"].includes(
-          w.operator
-        )
+        w.mode === "insensitive" ||
+        (w.operator &&
+          ["contains", "starts_with", "ends_with", "ne", "not_in"].includes(
+            w.operator
+          ))
     );
   });
   return filteredQuery;
@@ -497,17 +520,26 @@ export const paginate = async <
       `_id can only be used with eq, in, or not_in operator: ${JSON.stringify(args.where)}`
     );
   }
-  if (args.where?.some((w) => w.mode === "insensitive")) {
+  if (
+    args.where?.some(
+      (w) =>
+        w.mode === "insensitive" &&
+        w.operator &&
+        ["lt", "lte", "gt", "gte"].includes(w.operator)
+    )
+  ) {
     throw new Error(
-      `Case-insensitive queries (mode: "insensitive") are not supported by the Convex adapter. Store values in a normalized form (e.g. lowercase on write) and query against the normalized value.`
+      `Case-insensitive mode is not supported with range operators (lt/lte/gt/gte) by the Convex adapter: ${JSON.stringify(args.where)}`
     );
   }
   // If any where clause is "eq" (or missing operator) on a unique field,
   // we can only return a single document, so we get it and use any other
-  // where clauses as static filters.
+  // where clauses as static filters. Insensitive clauses can't use the
+  // index-backed unique lookup.
   const uniqueWhere = args.where?.find(
     (w) =>
       (!w.operator || w.operator === "eq") &&
+      w.mode !== "insensitive" &&
       (isUniqueField(betterAuthSchema, args.model, w.field) ||
         w.field === "_id")
   );
@@ -560,7 +592,11 @@ export const paginate = async <
   // possible with the organization plugin listing all members with a high
   // limit. For cases like this we need to create proper convex queries in
   // the component as an alternative to using Better Auth api's.
-  const inWhere = args.where?.find((w) => w.operator === "in");
+  // Insensitive "in" clauses can't fan out to index-backed point lookups;
+  // they fall through to the streaming query and are filtered statically.
+  const inWhere = args.where?.find(
+    (w) => w.operator === "in" && w.mode !== "insensitive"
+  );
   if (inWhere) {
     if (!Array.isArray(inWhere.value)) {
       throw new Error("in clause value must be an array");

--- a/src/client/adapter.test.ts
+++ b/src/client/adapter.test.ts
@@ -3,6 +3,7 @@
 import { describe, it } from "vitest";
 import { convexTest } from "convex-test";
 import {
+  caseInsensitiveTestSuite,
   testAdapter,
   transactionsTestSuite,
 } from "@better-auth/test-utils/adapter";
@@ -42,14 +43,9 @@ const NORMAL_DISABLED_TESTS = [
   // convex-id-generation:
   // Convex controls generated IDs at write time.
   "create - should use generateId if provided",
-  // offset-unsupported:
-  // Convex adapter rejects offset pagination.
+  // joins-unsupported:
+  // Better Auth experimental joins are not supported by the Convex adapter.
   "findMany - should be able to perform a complex limited join",
-  "findMany - should find many models with limit and offset",
-  "findMany - should find many models with offset",
-  "findMany - should find many models with sortBy and limit and offset",
-  "findMany - should find many models with sortBy and limit and offset and where",
-  "findMany - should find many models with sortBy and offset",
   "findMany - should find many with both one-to-one and one-to-many joins",
   "findMany - should find many with join and offset",
   "findMany - should find many with join, where, limit, and offset",
@@ -169,6 +165,7 @@ if (currentNodeMajor < MIN_NODE_MAJOR) {
         }),
         transactionsTestSuite({ disableTests: { ALL: true } }),
         coreAuthFlowTestSuite(),
+        caseInsensitiveTestSuite(),
         convexCustomTestSuite(),
       ],
     });

--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -107,13 +107,6 @@ const parseWhere = (
     return [];
   }
   const whereArray = Array.isArray(where) ? where : [where];
-  for (const w of whereArray) {
-    if (w.mode === "insensitive") {
-      throw new Error(
-        `Case-insensitive queries (mode: "insensitive") are not supported by the Convex adapter. Store values in a normalized form (e.g. lowercase on write) and query against the normalized value. Field: ${w.field}`
-      );
-    }
-  }
   return whereArray.map((w) => {
     if (w.value instanceof Date) {
       return {
@@ -124,6 +117,25 @@ const parseWhere = (
     return w;
   }) as ConvexCleanedWhere[];
 };
+
+// Better Auth where semantics: clauses with connector "OR" form a single
+// OR-group that is AND'd with all remaining (implicitly AND) clauses. The
+// component only evaluates AND-only where lists, so OR queries run as one
+// query per OR branch — each branch combined with the AND clauses — and the
+// results are unioned.
+const splitWhereByConnector = (where?: (Where & { join?: undefined })[]) => {
+  const orClauses = where?.filter((w) => w.connector === "OR") ?? [];
+  const andClauses = where?.filter((w) => w.connector !== "OR") ?? [];
+  return { orClauses, andClauses };
+};
+
+const orBranchWhere = (
+  orClause: Where & { join?: undefined },
+  andClauses: (Where & { join?: undefined })[]
+): (Where & { join?: undefined })[] => [
+  { ...orClause, connector: undefined },
+  ...andClauses,
+];
 
 type DocWithFlexibleId = {
   _id?: string | null;
@@ -246,12 +258,13 @@ export const convexAdapter = <
         model: string;
         where: (Where & { join?: undefined })[];
       }) => {
-        const results = await asyncMap(data.where, async (w) =>
+        const { orClauses, andClauses } = splitWhereByConnector(data.where);
+        const results = await asyncMap(orClauses, async (w) =>
           handlePagination(
             async ({ paginationOpts }) => {
               return await ctx.runQuery(api.adapter.findMany, {
                 model: data.model as TableNames,
-                where: parseWhere(w),
+                where: parseWhere(orBranchWhere(w, andClauses)),
                 paginationOpts,
               });
             }
@@ -289,17 +302,19 @@ export const convexAdapter = <
           });
         },
         findOne: async (data): Promise<any> => {
-          if (data.where?.every((w) => w.connector === "OR")) {
-            for (const w of data.where) {
+          const { orClauses, andClauses } = splitWhereByConnector(data.where);
+          if (orClauses.length) {
+            for (const w of orClauses) {
               const result = await ctx.runQuery(api.adapter.findOne, {
                 ...data,
                 model: data.model as TableNames,
-                where: parseWhere(w),
+                where: parseWhere(orBranchWhere(w, andClauses)),
               });
               if (result) {
                 return result;
               }
             }
+            return null;
           }
           return await ctx.runQuery(api.adapter.findOne, {
             ...data,
@@ -308,25 +323,29 @@ export const convexAdapter = <
           });
         },
         findMany: async (data): Promise<any[]> => {
-          if (data.offset) {
-            throw new Error("offset not supported");
-          }
+          // The component paginates by cursor and has no offset support;
+          // fetch offset + limit docs and drop the first `offset` here.
+          const offset = data.offset ?? 0;
+          const fetchLimit =
+            data.limit !== undefined ? data.limit + offset : undefined;
+          const { orClauses, andClauses } = splitWhereByConnector(data.where);
 
-          if (data.where?.some((w) => w.connector === "OR")) {
+          if (orClauses.length) {
             // Always fetch full docs for OR unions so we can dedupe
             // by id and sort/limit before trimming selected fields.
             const { select: _ignoredSelect, ...queryData } = data;
-            const results = await asyncMap(data.where, async (w) =>
+            const results = await asyncMap(orClauses, async (w) =>
               handlePagination(
                 async ({ paginationOpts }) => {
                   return await ctx.runQuery(api.adapter.findMany, {
                     ...queryData,
+                    offset: undefined,
                     model: data.model as TableNames,
-                    where: parseWhere(w),
+                    where: parseWhere(orBranchWhere(w, andClauses)),
                     paginationOpts,
                   });
                 },
-                { limit: data.limit }
+                { limit: fetchLimit }
               )
             );
             let docs = dedupeDocsById(results.flatMap((r) => r.docs));
@@ -336,9 +355,7 @@ export const convexAdapter = <
                 data.sortBy.direction,
               ]);
             }
-            if (data.limit !== undefined) {
-              docs = docs.slice(0, data.limit);
-            }
+            docs = docs.slice(offset, fetchLimit);
             return docs.map((doc) => selectDocFields(doc, data.select));
           }
 
@@ -346,24 +363,26 @@ export const convexAdapter = <
             async ({ paginationOpts }) => {
               return await ctx.runQuery(api.adapter.findMany, {
                 ...data,
+                offset: undefined,
                 model: data.model as TableNames,
                 where: parseWhere(data.where),
                 paginationOpts,
               });
             },
-            { limit: data.limit }
+            { limit: fetchLimit }
           );
-          return result.docs;
+          return offset ? result.docs.slice(offset) : result.docs;
         },
         count: async (data) => {
           // Yes, count is just findMany returning a number.
-          if (data.where?.some((w) => w.connector === "OR")) {
-            const results = await asyncMap(data.where, async (w) =>
+          const { orClauses, andClauses } = splitWhereByConnector(data.where);
+          if (orClauses.length) {
+            const results = await asyncMap(orClauses, async (w) =>
               handlePagination(async ({ paginationOpts }) => {
                 return await ctx.runQuery(api.adapter.findMany, {
                   ...data,
                   model: data.model as TableNames,
-                  where: parseWhere(w),
+                  where: parseWhere(orBranchWhere(w, andClauses)),
                   paginationOpts,
                 });
               })

--- a/src/test/adapter-factory/convex-custom.ts
+++ b/src/test/adapter-factory/convex-custom.ts
@@ -427,6 +427,155 @@ export const convexCustomTestSuite = createTestSuite(
       ]);
     },
 
+    "should combine OR where clauses with AND where clauses": async () => {
+      const alice = await adapter.create({
+        model: "user",
+        data: {
+          name: "Alice",
+          email: "alice@or-and.test",
+        },
+      });
+      const bob = await adapter.create({
+        model: "user",
+        data: {
+          name: "Bob",
+          email: "bob@or-and.test",
+        },
+      });
+      await adapter.create({
+        model: "user",
+        data: {
+          name: "Alice",
+          email: "alice@elsewhere.test",
+        },
+      });
+      // (name = Alice OR name = Bob) AND email ends_with @or-and.test
+      const mixedWhere = [
+        { field: "name", value: "Alice", connector: "OR" as const },
+        { field: "name", value: "Bob", connector: "OR" as const },
+        {
+          field: "email",
+          operator: "ends_with" as const,
+          value: "@or-and.test",
+        },
+      ];
+      const results = await adapter.findMany<{ id: string }>({
+        model: "user",
+        where: mixedWhere,
+        sortBy: { field: "name", direction: "asc" },
+      });
+      expect(results).toEqual([alice, bob]);
+      expect(
+        await adapter.count({
+          model: "user",
+          where: mixedWhere,
+        }),
+      ).toEqual(2);
+      expect(
+        await adapter.findOne({
+          model: "user",
+          where: [
+            { field: "name", value: "Nobody", connector: "OR" },
+            { field: "name", value: "Bob", connector: "OR" },
+            {
+              field: "email",
+              operator: "ends_with",
+              value: "@or-and.test",
+            },
+          ],
+        }),
+      ).toEqual(bob);
+    },
+
+    "should return null from findOne when no OR clause matches": async () => {
+      await adapter.create({
+        model: "user",
+        data: {
+          name: "solo",
+          email: "solo@none.test",
+        },
+      });
+      expect(
+        await adapter.findOne({
+          model: "user",
+          where: [
+            { field: "name", value: "missing-one", connector: "OR" },
+            { field: "name", value: "missing-two", connector: "OR" },
+          ],
+        }),
+      ).toEqual(null);
+    },
+
+    "should apply offset to OR unions": async () => {
+      const users = [];
+      for (const letter of ["a", "b", "c", "d"]) {
+        users.push(
+          await adapter.create({
+            model: "user",
+            data: {
+              name: "offset-user",
+              email: `${letter}@offset-or.test`,
+            },
+          }),
+        );
+      }
+      const page = await adapter.findMany({
+        model: "user",
+        where: [
+          { field: "name", value: "offset-user", connector: "OR" },
+          { field: "email", value: "none@offset-or.test", connector: "OR" },
+        ],
+        sortBy: { field: "email", direction: "asc" },
+        limit: 2,
+        offset: 1,
+      });
+      expect(page).toEqual([users[1], users[2]]);
+    },
+
+    "should update records matching OR clauses combined with AND clauses":
+      async () => {
+        const target = await adapter.create({
+          model: "user",
+          data: {
+            name: "update-me",
+            email: "target@mixed-update.test",
+          },
+        });
+        const excludedByAnd = await adapter.create({
+          model: "user",
+          data: {
+            name: "update-me",
+            email: "excluded@elsewhere.test",
+          },
+        });
+        const updatedCount = await adapter.updateMany({
+          model: "user",
+          where: [
+            { field: "name", value: "update-me", connector: "OR" },
+            { field: "name", value: "also-update-me", connector: "OR" },
+            {
+              field: "email",
+              operator: "ends_with",
+              value: "@mixed-update.test",
+            },
+          ],
+          update: { name: "updated" },
+        });
+        expect(updatedCount).toEqual(1);
+        expect(
+          await adapter.findOne<{ name: string }>({
+            model: "user",
+            where: [{ field: "id", value: target.id }],
+          }),
+        ).toMatchObject({ name: "updated" });
+        expect(
+          await adapter.findOne<{ name: string }>({
+            model: "user",
+            where: [{ field: "id", value: excludedByAnd.id }],
+          }),
+        ).toMatchObject({ name: "update-me" });
+      },
+
     "should return null and not modify records when update where is empty":
       async () => {
         const user = await adapter.create({
@@ -761,7 +910,7 @@ export const convexCustomTestSuite = createTestSuite(
       expect(typeof user.createdAt).toBe("number");
     },
 
-    "should reject case-insensitive where clauses": async () => {
+    "should reject case-insensitive range operators": async () => {
       await adapter.create({
         model: "user",
         data: {
@@ -769,19 +918,21 @@ export const convexCustomTestSuite = createTestSuite(
           email: "foo@bar.com",
         },
       });
+      // Case-insensitive ordering is ambiguous; only equality/string
+      // matching operators support mode: "insensitive".
       await expect(
-        adapter.findOne({
+        adapter.findMany({
           model: "user",
           where: [
             {
               field: "email",
               value: "FOO@BAR.COM",
-              operator: "eq",
+              operator: "lt",
               mode: "insensitive",
             },
           ],
         }),
-      ).rejects.toThrow(/mode: "insensitive"/);
+      ).rejects.toThrow(/range operators/);
     },
   }),
 );

--- a/src/test/adapter-factory/profile-additional-fields.ts
+++ b/src/test/adapter-factory/profile-additional-fields.ts
@@ -10,6 +10,9 @@ export const ADDITIONAL_FIELDS_NORMAL_TESTS = [
   "deleteMany - should delete many models with numeric values",
   "findMany - should find many models with sortBy",
   "findMany - should find many models with sortBy and limit",
+  "findMany - should find many models with sortBy and limit and offset",
+  "findMany - should find many models with sortBy and limit and offset and where",
+  "findMany - should find many models with sortBy and offset",
   "findMany - should find many with join and sortBy",
   "findOne - should find a model with additional fields",
 ] as const;


### PR DESCRIPTION
## Motivation

The Better Auth dashboard (`@better-auth/infra` dash plugin) drives its admin UI through the adapter (`/dash/execute-adapter` and the list endpoints). Against the Convex adapter, three of its query shapes fail today:

- User/organization search sends `contains` / `starts_with` clauses with `mode: "insensitive"` → the adapter throws.
- Table paging sends `offset` → `findMany` throws `offset not supported`.
- Search terms are `OR` clauses combined with `AND` filters (e.g. a `createdAt` range) → the adapter unions *every* clause, so the AND filters are silently treated as ORs.

This PR makes those query shapes work.

## Changes

**1. `mode: "insensitive"` for `eq`/`ne`/`in`/`not_in`/`contains`/`starts_with`/`ends_with`**
Insensitive clauses are excluded from index selection and from the unique-field fast path, and evaluated as static filters with both sides folded to lowercase. Range operators (`lt`/`lte`/`gt`/`gte`) with insensitive mode still throw — case-insensitive ordering is ambiguous.

**2. `findMany` offset**
The client fetches `offset + limit` rows through the existing cursor pagination and drops the first `offset` rows. The component stays cursor-only. This is aimed at admin-style paging; deep offsets still read `offset + limit` rows.

**3. Mixed `AND`/`OR` where clauses**
`where` is partitioned into the OR-group and the AND clauses; each OR branch is queried AND'd with the AND clauses and the results are unioned/deduped (matching Better Auth's `AND(...) AND OR(...)` semantics). Applies to `findOne`, `findMany`, `count`, and `updateMany`/`deleteMany` via `collectIdsForOrWhere`. Also fixes `findOne` with an all-OR where and no match: it previously fell through to a combined query that the component rejects; it now returns `null`.

## Tests

- Enabled the upstream `caseInsensitiveTestSuite`.
- Re-enabled the upstream offset tests. The three `sortBy and offset` variants mutate runtime schema (`numericField` additional field), so they follow the existing pattern: added to `ADDITIONAL_FIELDS_NORMAL_TESTS` and run in the additional-fields profile, which has the static field + index.
- New `convex-custom` tests: OR+AND combination for `findMany`/`count`/`findOne`, `findOne` → `null` when no OR branch matches, offset applied to OR unions, `updateMany` with mixed clauses.
- Replaced `should reject case-insensitive where clauses` with `should reject case-insensitive range operators`.

`npm run build`, `tsc --noEmit`, and the full vitest suite pass: 10 files, 204 passed | 26 skipped (main baseline: 131 passed).
