### PR TITLE
Fix AND where clauses being dropped when combined with OR clauses

### DIFF
--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -125,6 +125,25 @@ const parseWhere = (
   }) as ConvexCleanedWhere[];
 };
 
+// Better Auth where semantics: clauses with connector "OR" form a single
+// OR-group that is AND'd with all remaining (implicitly AND) clauses. The
+// component only evaluates AND-only where lists, so OR queries run as one
+// query per OR branch — each branch combined with the AND clauses — and the
+// results are unioned.
+const splitWhereByConnector = (where?: (Where & { join?: undefined })[]) => {
+  const orClauses = where?.filter((w) => w.connector === "OR") ?? [];
+  const andClauses = where?.filter((w) => w.connector !== "OR") ?? [];
+  return { orClauses, andClauses };
+};
+
+const orBranchWhere = (
+  orClause: Where & { join?: undefined },
+  andClauses: (Where & { join?: undefined })[]
+): (Where & { join?: undefined })[] => [
+  { ...orClause, connector: undefined },
+  ...andClauses,
+];
+
 type DocWithFlexibleId = {
   _id?: string | null;
   id?: string | null;
@@ -246,12 +265,13 @@ export const convexAdapter = <
         model: string;
         where: (Where & { join?: undefined })[];
       }) => {
-        const results = await asyncMap(data.where, async (w) =>
+        const { orClauses, andClauses } = splitWhereByConnector(data.where);
+        const results = await asyncMap(orClauses, async (w) =>
           handlePagination(
             async ({ paginationOpts }) => {
               return await ctx.runQuery(api.adapter.findMany, {
                 model: data.model as TableNames,
-                where: parseWhere(w),
+                where: parseWhere(orBranchWhere(w, andClauses)),
                 paginationOpts,
               });
             }
@@ -289,17 +309,19 @@ export const convexAdapter = <
           });
         },
         findOne: async (data): Promise<any> => {
-          if (data.where?.every((w) => w.connector === "OR")) {
-            for (const w of data.where) {
+          const { orClauses, andClauses } = splitWhereByConnector(data.where);
+          if (orClauses.length) {
+            for (const w of orClauses) {
               const result = await ctx.runQuery(api.adapter.findOne, {
                 ...data,
                 model: data.model as TableNames,
-                where: parseWhere(w),
+                where: parseWhere(orBranchWhere(w, andClauses)),
               });
               if (result) {
                 return result;
               }
             }
+            return null;
           }
           return await ctx.runQuery(api.adapter.findOne, {
             ...data,
@@ -312,17 +334,18 @@ export const convexAdapter = <
             throw new Error("offset not supported");
           }
 
-          if (data.where?.some((w) => w.connector === "OR")) {
+          const { orClauses, andClauses } = splitWhereByConnector(data.where);
+          if (orClauses.length) {
             // Always fetch full docs for OR unions so we can dedupe
             // by id and sort/limit before trimming selected fields.
             const { select: _ignoredSelect, ...queryData } = data;
-            const results = await asyncMap(data.where, async (w) =>
+            const results = await asyncMap(orClauses, async (w) =>
               handlePagination(
                 async ({ paginationOpts }) => {
                   return await ctx.runQuery(api.adapter.findMany, {
                     ...queryData,
                     model: data.model as TableNames,
-                    where: parseWhere(w),
+                    where: parseWhere(orBranchWhere(w, andClauses)),
                     paginationOpts,
                   });
                 },
@@ -357,13 +380,14 @@ export const convexAdapter = <
         },
         count: async (data) => {
           // Yes, count is just findMany returning a number.
-          if (data.where?.some((w) => w.connector === "OR")) {
-            const results = await asyncMap(data.where, async (w) =>
+          const { orClauses, andClauses } = splitWhereByConnector(data.where);
+          if (orClauses.length) {
+            const results = await asyncMap(orClauses, async (w) =>
               handlePagination(async ({ paginationOpts }) => {
                 return await ctx.runQuery(api.adapter.findMany, {
                   ...data,
                   model: data.model as TableNames,
-                  where: parseWhere(w),
+                  where: parseWhere(orBranchWhere(w, andClauses)),
                   paginationOpts,
                 });
               })

--- a/src/test/adapter-factory/convex-custom.ts
+++ b/src/test/adapter-factory/convex-custom.ts
@@ -427,6 +427,129 @@ export const convexCustomTestSuite = createTestSuite(
       ]);
     },
 
+    "should combine OR where clauses with AND where clauses": async () => {
+      const alice = await adapter.create({
+        model: "user",
+        data: {
+          name: "Alice",
+          email: "alice@or-and.test",
+        },
+      });
+      const bob = await adapter.create({
+        model: "user",
+        data: {
+          name: "Bob",
+          email: "bob@or-and.test",
+        },
+      });
+      await adapter.create({
+        model: "user",
+        data: {
+          name: "Alice",
+          email: "alice@elsewhere.test",
+        },
+      });
+      // (name = Alice OR name = Bob) AND email ends_with @or-and.test
+      const mixedWhere = [
+        { field: "name", value: "Alice", connector: "OR" as const },
+        { field: "name", value: "Bob", connector: "OR" as const },
+        {
+          field: "email",
+          operator: "ends_with" as const,
+          value: "@or-and.test",
+        },
+      ];
+      const results = await adapter.findMany<{ id: string }>({
+        model: "user",
+        where: mixedWhere,
+        sortBy: { field: "name", direction: "asc" },
+      });
+      expect(results).toEqual([alice, bob]);
+      expect(
+        await adapter.count({
+          model: "user",
+          where: mixedWhere,
+        }),
+      ).toEqual(2);
+      expect(
+        await adapter.findOne({
+          model: "user",
+          where: [
+            { field: "name", value: "Nobody", connector: "OR" },
+            { field: "name", value: "Bob", connector: "OR" },
+            {
+              field: "email",
+              operator: "ends_with",
+              value: "@or-and.test",
+            },
+          ],
+        }),
+      ).toEqual(bob);
+    },
+
+    "should return null from findOne when no OR clause matches": async () => {
+      await adapter.create({
+        model: "user",
+        data: {
+          name: "solo",
+          email: "solo@none.test",
+        },
+      });
+      expect(
+        await adapter.findOne({
+          model: "user",
+          where: [
+            { field: "name", value: "missing-one", connector: "OR" },
+            { field: "name", value: "missing-two", connector: "OR" },
+          ],
+        }),
+      ).toEqual(null);
+    },
+
+    "should update records matching OR clauses combined with AND clauses":
+      async () => {
+        const target = await adapter.create({
+          model: "user",
+          data: {
+            name: "update-me",
+            email: "target@mixed-update.test",
+          },
+        });
+        const excludedByAnd = await adapter.create({
+          model: "user",
+          data: {
+            name: "update-me",
+            email: "excluded@elsewhere.test",
+          },
+        });
+        const updatedCount = await adapter.updateMany({
+          model: "user",
+          where: [
+            { field: "name", value: "update-me", connector: "OR" },
+            { field: "name", value: "also-update-me", connector: "OR" },
+            {
+              field: "email",
+              operator: "ends_with",
+              value: "@mixed-update.test",
+            },
+          ],
+          update: { name: "updated" },
+        });
+        expect(updatedCount).toEqual(1);
+        expect(
+          await adapter.findOne<{ name: string }>({
+            model: "user",
+            where: [{ field: "id", value: target.id }],
+          }),
+        ).toMatchObject({ name: "updated" });
+        expect(
+          await adapter.findOne<{ name: string }>({
+            model: "user",
+            where: [{ field: "id", value: excludedByAnd.id }],
+          }),
+        ).toMatchObject({ name: "update-me" });
+      },
+
     "should return null and not modify records when update where is empty":
       async () => {
         const user = await adapter.create({


### PR DESCRIPTION
## Motivation

Better Auth where semantics: clauses with `connector: "OR"` form a single OR-group that is AND'd with the remaining (implicitly AND) clauses — `AND(...) AND OR(...)`. The Convex adapter currently unions *every* clause as an OR branch, so AND filters are silently dropped. For example, the dashboard's user search sends its search term as OR clauses combined with a `createdAt` range filter — the range filter is ignored and the query returns rows outside the range. This affects `findOne`, `findMany`, `count`, and (via `collectIdsForOrWhere`) `updateMany`/`deleteMany`.

Separately, `findOne` with an all-OR where and no matching branch fell through to a combined query that the component rejects (`OR connector not supported with multiple where statements`) instead of returning `null`.

## Changes

- `where` is partitioned into the OR-group and the AND clauses (`splitWhereByConnector`); each OR branch runs as one component query AND'd with the AND clauses (`orBranchWhere`), and results are unioned/deduped.
- Applies to `findOne`, `findMany`, `count`, and `updateMany`/`deleteMany` via `collectIdsForOrWhere`.
- `findOne` returns `null` when no OR branch matches instead of falling through.

## Behavior change

`updateMany`/`deleteMany` with a mixed AND/OR where now affect only rows matching `(OR-group) AND (AND clauses)` — previously they affected the broader all-OR union. That is the bug being fixed, but any caller relying on the old behavior will see fewer rows affected.

## Tests

New `convex-custom` tests: OR+AND combination for `findMany`/`count`/`findOne`, `findOne` → `null` when no OR branch matches, `updateMany` with mixed clauses.

`npm run build`, `npm run typecheck` (src), and the full vitest suite pass: 10 files, 185 passed | 31 skipped (main baseline: 182 passed | 31 skipped).

Note: this touches the same `findMany` region as the offset PR; whichever merges second will be rebased promptly.
