### PR TITLE
Support case-insensitive string filters via static filtering

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -129,7 +129,10 @@ const findIndex = (
         ["lt", "lte", "gt", "gte", "eq", "in", "not_in"].includes(
           w.operator
         )) &&
-      w.field !== "_id"
+      w.field !== "_id" &&
+      // Convex index lookups are case-sensitive; insensitive clauses are
+      // applied as static filters instead.
+      w.mode !== "insensitive"
     );
   });
   if (!where?.length && !args.sortBy) {
@@ -340,17 +343,28 @@ const filterByWhere = <
       return val > wVal;
     };
     const filter = (w: Infer<typeof adapterWhereValidator>) => {
+      // Case-insensitive matching folds both sides to lowercase. Range
+      // operators (lt/lte/gt/gte) stay case-sensitive; paginate rejects
+      // insensitive mode for those.
+      const fold = <V>(val: V): V =>
+        w.mode === "insensitive" && typeof val === "string"
+          ? (val.toLowerCase() as V)
+          : val;
       switch (w.operator) {
         case undefined:
         case "eq": {
-          return value === w.value;
+          return fold(value) === fold(w.value);
         }
         case "in": {
-          return Array.isArray(w.value) && (w.value as any[]).includes(value);
+          return (
+            Array.isArray(w.value) &&
+            (w.value as any[]).map(fold).includes(fold(value))
+          );
         }
         case "not_in": {
           const result =
-            Array.isArray(w.value) && !(w.value as any[]).includes(value);
+            Array.isArray(w.value) &&
+            !(w.value as any[]).map(fold).includes(fold(value));
           return result;
         }
         case "lt": {
@@ -366,18 +380,25 @@ const filterByWhere = <
           return value === w.value || isGreaterThan(value, w.value);
         }
         case "ne": {
-          return value !== w.value;
+          return fold(value) !== fold(w.value);
         }
         case "contains": {
-          return typeof value === "string" && value.includes(w.value as string);
+          return (
+            typeof value === "string" &&
+            fold(value).includes(fold(w.value) as string)
+          );
         }
         case "starts_with": {
           return (
-            typeof value === "string" && value.startsWith(w.value as string)
+            typeof value === "string" &&
+            fold(value).startsWith(fold(w.value) as string)
           );
         }
         case "ends_with": {
-          return typeof value === "string" && value.endsWith(w.value as string);
+          return (
+            typeof value === "string" &&
+            fold(value).endsWith(fold(w.value) as string)
+          );
         }
       }
     };
@@ -452,12 +473,14 @@ const generateQuery = (
       doc,
       args.where,
       // Index used for all eq and range clauses, apply remaining clauses
-      // incompatible with Convex statically.
+      // incompatible with Convex statically. Insensitive clauses are always
+      // excluded from index selection, so they must be applied here too.
       (w) =>
-        w.operator &&
-        ["contains", "starts_with", "ends_with", "ne", "not_in"].includes(
-          w.operator
-        )
+        w.mode === "insensitive" ||
+        (w.operator &&
+          ["contains", "starts_with", "ends_with", "ne", "not_in"].includes(
+            w.operator
+          ))
     );
   });
   return filteredQuery;
@@ -497,17 +520,26 @@ export const paginate = async <
       `_id can only be used with eq, in, or not_in operator: ${JSON.stringify(args.where)}`
     );
   }
-  if (args.where?.some((w) => w.mode === "insensitive")) {
+  if (
+    args.where?.some(
+      (w) =>
+        w.mode === "insensitive" &&
+        w.operator &&
+        ["lt", "lte", "gt", "gte"].includes(w.operator)
+    )
+  ) {
     throw new Error(
-      `Case-insensitive queries (mode: "insensitive") are not supported by the Convex adapter. Store values in a normalized form (e.g. lowercase on write) and query against the normalized value.`
+      `Case-insensitive mode is not supported with range operators (lt/lte/gt/gte) by the Convex adapter: ${JSON.stringify(args.where)}`
     );
   }
   // If any where clause is "eq" (or missing operator) on a unique field,
   // we can only return a single document, so we get it and use any other
-  // where clauses as static filters.
+  // where clauses as static filters. Insensitive clauses can't use the
+  // index-backed unique lookup.
   const uniqueWhere = args.where?.find(
     (w) =>
       (!w.operator || w.operator === "eq") &&
+      w.mode !== "insensitive" &&
       (isUniqueField(betterAuthSchema, args.model, w.field) ||
         w.field === "_id")
   );
@@ -560,7 +592,11 @@ export const paginate = async <
   // possible with the organization plugin listing all members with a high
   // limit. For cases like this we need to create proper convex queries in
   // the component as an alternative to using Better Auth api's.
-  const inWhere = args.where?.find((w) => w.operator === "in");
+  // Insensitive "in" clauses can't fan out to index-backed point lookups;
+  // they fall through to the streaming query and are filtered statically.
+  const inWhere = args.where?.find(
+    (w) => w.operator === "in" && w.mode !== "insensitive"
+  );
   if (inWhere) {
     if (!Array.isArray(inWhere.value)) {
       throw new Error("in clause value must be an array");

--- a/src/client/adapter.test.ts
+++ b/src/client/adapter.test.ts
@@ -3,6 +3,7 @@
 import { describe, it } from "vitest";
 import { convexTest } from "convex-test";
 import {
+  caseInsensitiveTestSuite,
   testAdapter,
   transactionsTestSuite,
 } from "@better-auth/test-utils/adapter";
@@ -169,6 +170,7 @@ if (currentNodeMajor < MIN_NODE_MAJOR) {
         }),
         transactionsTestSuite({ disableTests: { ALL: true } }),
         coreAuthFlowTestSuite(),
+        caseInsensitiveTestSuite(),
         convexCustomTestSuite(),
       ],
     });

--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -107,13 +107,6 @@ const parseWhere = (
     return [];
   }
   const whereArray = Array.isArray(where) ? where : [where];
-  for (const w of whereArray) {
-    if (w.mode === "insensitive") {
-      throw new Error(
-        `Case-insensitive queries (mode: "insensitive") are not supported by the Convex adapter. Store values in a normalized form (e.g. lowercase on write) and query against the normalized value. Field: ${w.field}`
-      );
-    }
-  }
   return whereArray.map((w) => {
     if (w.value instanceof Date) {
       return {

--- a/src/test/adapter-factory/convex-custom.ts
+++ b/src/test/adapter-factory/convex-custom.ts
@@ -761,7 +761,7 @@ export const convexCustomTestSuite = createTestSuite(
       expect(typeof user.createdAt).toBe("number");
     },
 
-    "should reject case-insensitive where clauses": async () => {
+    "should reject case-insensitive range operators": async () => {
       await adapter.create({
         model: "user",
         data: {
@@ -769,19 +769,21 @@ export const convexCustomTestSuite = createTestSuite(
           email: "foo@bar.com",
         },
       });
+      // Case-insensitive ordering is ambiguous; only equality/string
+      // matching operators support mode: "insensitive".
       await expect(
-        adapter.findOne({
+        adapter.findMany({
           model: "user",
           where: [
             {
               field: "email",
               value: "FOO@BAR.COM",
-              operator: "eq",
+              operator: "lt",
               mode: "insensitive",
             },
           ],
         }),
-      ).rejects.toThrow(/mode: "insensitive"/);
+      ).rejects.toThrow(/range operators/);
     },
   }),
 );


### PR DESCRIPTION
## Motivation

The adapter currently rejects any where clause with `mode: "insensitive"`. Several Better Auth surfaces send them — e.g. the dashboard's user/organization search sends `contains` / `starts_with` clauses with `mode: "insensitive"` — and those queries throw against the Convex adapter today. This PR supports them and enables the upstream `caseInsensitiveTestSuite`.

## Changes

- `mode: "insensitive"` is supported for `eq`/`ne`/`in`/`not_in`/`contains`/`starts_with`/`ends_with`: both sides are folded to lowercase and evaluated as static filters.
- Insensitive clauses are excluded from index selection, from the unique-field fast path, and from the `in` fan-out to point lookups — Convex index lookups are case-sensitive.
- Range operators (`lt`/`lte`/`gt`/`gte`) with insensitive mode still throw: case-insensitive ordering is ambiguous.

## Performance note

An insensitive `eq` on a unique/indexed field (e.g. `email`) cannot use the index-backed lookup — it streams the table and filters statically, O(table size). For hot paths the existing recommendation stands: store values normalized (lowercased) on write and query case-sensitively. Happy to add a docs note if you can point me at where you'd want it — I didn't find an adapter-limitations section to update.

## Tests

- Enabled the upstream `caseInsensitiveTestSuite`.
- Replaced the `convex-custom` test `should reject case-insensitive where clauses` with `should reject case-insensitive range operators`.

`npm run build`, `npm run typecheck` (src), and the full vitest suite pass: 10 files, 195 passed | 31 skipped (main baseline: 182 passed | 31 skipped).
