### PR TITLE
Support findMany offset via cursor pagination

### DIFF
--- a/src/client/adapter.test.ts
+++ b/src/client/adapter.test.ts
@@ -42,14 +42,9 @@ const NORMAL_DISABLED_TESTS = [
   // convex-id-generation:
   // Convex controls generated IDs at write time.
   "create - should use generateId if provided",
-  // offset-unsupported:
-  // Convex adapter rejects offset pagination.
+  // joins-unsupported:
+  // Better Auth experimental joins are not supported by the Convex adapter.
   "findMany - should be able to perform a complex limited join",
-  "findMany - should find many models with limit and offset",
-  "findMany - should find many models with offset",
-  "findMany - should find many models with sortBy and limit and offset",
-  "findMany - should find many models with sortBy and limit and offset and where",
-  "findMany - should find many models with sortBy and offset",
   "findMany - should find many with both one-to-one and one-to-many joins",
   "findMany - should find many with join and offset",
   "findMany - should find many with join, where, limit, and offset",

--- a/src/client/adapter.ts
+++ b/src/client/adapter.ts
@@ -308,9 +308,11 @@ export const convexAdapter = <
           });
         },
         findMany: async (data): Promise<any[]> => {
-          if (data.offset) {
-            throw new Error("offset not supported");
-          }
+          // The component paginates by cursor and has no offset support;
+          // fetch offset + limit docs and drop the first `offset` here.
+          const offset = data.offset ?? 0;
+          const fetchLimit =
+            data.limit !== undefined ? data.limit + offset : undefined;
 
           if (data.where?.some((w) => w.connector === "OR")) {
             // Always fetch full docs for OR unions so we can dedupe
@@ -321,12 +323,13 @@ export const convexAdapter = <
                 async ({ paginationOpts }) => {
                   return await ctx.runQuery(api.adapter.findMany, {
                     ...queryData,
+                    offset: undefined,
                     model: data.model as TableNames,
                     where: parseWhere(w),
                     paginationOpts,
                   });
                 },
-                { limit: data.limit }
+                { limit: fetchLimit }
               )
             );
             let docs = dedupeDocsById(results.flatMap((r) => r.docs));
@@ -336,9 +339,7 @@ export const convexAdapter = <
                 data.sortBy.direction,
               ]);
             }
-            if (data.limit !== undefined) {
-              docs = docs.slice(0, data.limit);
-            }
+            docs = docs.slice(offset, fetchLimit);
             return docs.map((doc) => selectDocFields(doc, data.select));
           }
 
@@ -346,14 +347,15 @@ export const convexAdapter = <
             async ({ paginationOpts }) => {
               return await ctx.runQuery(api.adapter.findMany, {
                 ...data,
+                offset: undefined,
                 model: data.model as TableNames,
                 where: parseWhere(data.where),
                 paginationOpts,
               });
             },
-            { limit: data.limit }
+            { limit: fetchLimit }
           );
-          return result.docs;
+          return offset ? result.docs.slice(offset) : result.docs;
         },
         count: async (data) => {
           // Yes, count is just findMany returning a number.

--- a/src/test/adapter-factory/convex-custom.ts
+++ b/src/test/adapter-factory/convex-custom.ts
@@ -451,6 +451,32 @@ export const convexCustomTestSuite = createTestSuite(
         ).toEqual(user);
       },
 
+    "should apply offset to OR unions": async () => {
+      const users = [];
+      for (const letter of ["a", "b", "c", "d"]) {
+        users.push(
+          await adapter.create({
+            model: "user",
+            data: {
+              name: "offset-user",
+              email: `${letter}@offset-or.test`,
+            },
+          }),
+        );
+      }
+      const page = await adapter.findMany({
+        model: "user",
+        where: [
+          { field: "name", value: "offset-user", connector: "OR" },
+          { field: "email", value: "none@offset-or.test", connector: "OR" },
+        ],
+        sortBy: { field: "email", direction: "asc" },
+        limit: 2,
+        offset: 1,
+      });
+      expect(page).toEqual([users[1], users[2]]);
+    },
+
     "should update and count each match only once for overlapping OR clauses":
       async () => {
         const foo = await adapter.create({

--- a/src/test/adapter-factory/profile-additional-fields.ts
+++ b/src/test/adapter-factory/profile-additional-fields.ts
@@ -10,6 +10,9 @@ export const ADDITIONAL_FIELDS_NORMAL_TESTS = [
   "deleteMany - should delete many models with numeric values",
   "findMany - should find many models with sortBy",
   "findMany - should find many models with sortBy and limit",
+  "findMany - should find many models with sortBy and limit and offset",
+  "findMany - should find many models with sortBy and limit and offset and where",
+  "findMany - should find many models with sortBy and offset",
   "findMany - should find many with join and sortBy",
   "findOne - should find a model with additional fields",
 ] as const;


### PR DESCRIPTION
## Motivation

`findMany` throws `offset not supported`, but some Better Auth surfaces pass `offset` — e.g. the dashboard's table paging. This PR supports it and re-enables the five upstream offset tests in `@better-auth/test-utils`.

## Changes

The component paginates by cursor and stays cursor-only. The client fetches `offset + limit` rows through the existing cursor pagination and drops the first `offset` rows; `offset` is stripped from the component query args.

## Cost

- `offset + limit` reads exactly `offset + limit` rows — deep offsets cost proportionally, the same as any cursor-based store emulating offset. This is aimed at admin-style paging.
- `offset` *without* `limit` can't be rejected (three of the four upstream offset tests pass `offset` with no `limit`), but it's cost-equivalent to the already-supported no-limit `findMany`, which pages 200 rows at a time to the end — no new unboundedness is introduced.

## Tests

- Re-enabled the upstream offset tests. The three `sortBy and offset` variants mutate runtime schema (`numericField` additional field), so they follow the existing pattern: added to `ADDITIONAL_FIELDS_NORMAL_TESTS` and run in the additional-fields profile, which has the static field + index.
- New `convex-custom` test: offset applied to OR unions.

`npm run build`, `npm run typecheck` (src), and the full vitest suite pass: 10 files, 188 passed | 26 skipped (main baseline: 182 passed | 31 skipped).

Note: this touches the same `findMany` region as #404; whichever merges second will be rebased promptly.
