### PR TITLE
Fix _id where-clauses matching documents from other models

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -1,6 +1,6 @@
 import { asyncMap } from "convex-helpers";
 import { v } from "convex/values";
-import type { GenericId, Infer } from "convex/values";
+import type { Infer } from "convex/values";
 import type {
   DocumentByName,
   GenericDataModel,
@@ -522,11 +522,17 @@ export const paginate = async <
         `No index found for ${args.model}.${uniqueWhere.field}`
       );
     }
+    // Resolve _id values through the requested model. normalizeId returns
+    // null when the id belongs to a different table or isn't a valid id at
+    // all (e.g. better-auth's adapter tests pass in UUIDs as values), both
+    // of which mean "no match" here.
+    const uniqueWhereId =
+      uniqueWhere.field === "_id" && typeof uniqueWhere.value === "string"
+        ? ctx.db.normalizeId(args.model as T, uniqueWhere.value)
+        : null;
     const doc =
       uniqueWhere.field === "_id"
-        ? // Unfortunately this is one place where tests pass in UUIDs as values and convex-test doesn't support them
-          // eslint-disable-next-line @convex-dev/explicit-table-ids
-          await ctx.db.get(uniqueWhere.value as GenericId<T>)
+        ? uniqueWhereId && (await ctx.db.get(args.model, uniqueWhereId))
         : await ctx.db
             .query(args.model as any)
             .withIndex(index?.indexDescriptor as any, (q) =>
@@ -568,7 +574,13 @@ export const paginate = async <
     // For ids, just use asyncMap + .get()
     if (inWhere.field === "_id") {
       const docs = await asyncMap(inWhere.value as any[], async (value) => {
-        return ctx.db.get(args.model, value as GenericId<T>);
+        // Same model scoping as the unique _id branch above: foreign or
+        // invalid ids are filtered out instead of matching or throwing.
+        const id =
+          typeof value === "string"
+            ? ctx.db.normalizeId(args.model as T, value)
+            : null;
+        return id && (await ctx.db.get(args.model, id));
       });
       const filteredDocs = docs
         .flatMap((doc) => (doc ? [doc] : []))

--- a/src/test/adapter-factory/convex-custom.ts
+++ b/src/test/adapter-factory/convex-custom.ts
@@ -63,6 +63,41 @@ export const convexCustomTestSuite = createTestSuite(
       ).toEqual([user]);
     },
 
+    "should not match an id from a different model": async () => {
+      const user = await adapter.create({
+        model: "user",
+        data: {
+          name: "cross-model",
+          email: "cross@model.com",
+        },
+      });
+      // user.id is a valid id of the user table; a lookup scoped to another
+      // model must treat it as no match instead of returning the user doc.
+      expect(
+        await adapter.findOne({
+          model: "session",
+          where: [
+            {
+              field: "id",
+              value: user.id,
+            },
+          ],
+        }),
+      ).toEqual(null);
+      expect(
+        await adapter.findMany({
+          model: "session",
+          where: [
+            {
+              field: "id",
+              operator: "in",
+              value: [user.id],
+            },
+          ],
+        }),
+      ).toEqual([]);
+    },
+
     "should handle compound indexes that include id field": async () => {
       const user = await adapter.create({
         model: "user",


### PR DESCRIPTION
Fixes #410.

- `findOne`/`findMany` with an `_id` where-clause resolved the id with a bare `ctx.db.get(value)`, which returns whatever document the id points to regardless of the requested model, so any valid id of another table matched.
- Resolve `_id` values through `ctx.db.normalizeId(args.model, value)` first: foreign-table ids and invalid id strings both become "no match". This also covers the UUID values passed by better-auth's adapter tests that motivated the `@convex-dev/explicit-table-ids` exemption in #347 (`convex-test`'s `normalizeId` returns null for them), so the exemption is removed. With it gone, every `ctx.db.get` in the package is table-scoped.
- Same treatment on the `in` branch, which since #347 throws `InvalidTable` on foreign ids instead of filtering them out.
- Adds a regression test; on main it fails on both assertions (findOne returns the foreign document, findMany with `in` throws).

Update/delete flows resolve their target through the same `paginate` path, so they are covered transitively. Side note: the two-arg `db.get(table, id)` overload needs convex 1.31+, which the package already de facto requires since #347 (the create and in-branch paths use it), while the `convex` peerDependency still says `^1.25.0`; might be worth bumping separately.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
