### PR TITLE
fix(react-start): buffer proxied auth responses to avoid empty 400 under Connection: close

### DIFF
--- a/src/react-start/index.test.ts
+++ b/src/react-start/index.test.ts
@@ -89,3 +89,32 @@ describe("convexBetterAuthReactStart handler", () => {
     expect(init.body).toBeDefined();
   });
 });
+
+  it("buffers the upstream response body and strips hop-by-hop response headers", async () => {
+    const { handler, fetchSpy } = setup();
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "set-cookie": "a=1; Path=/",
+          connection: "keep-alive",
+          "transfer-encoding": "chunked",
+          "keep-alive": "timeout=5",
+        },
+      })
+    );
+    const request = new Request("https://app.example.com/api/auth/ok", {
+      method: "GET",
+    });
+    const response = await handler(request);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("set-cookie")).toBe("a=1; Path=/");
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("transfer-encoding")).toBeNull();
+    expect(response.headers.get("keep-alive")).toBeNull();
+    // Body is fully materialized (not an undici network stream).
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+

--- a/src/react-start/index.test.ts
+++ b/src/react-start/index.test.ts
@@ -75,6 +75,7 @@ describe("convexBetterAuthReactStart handler", () => {
     expect(headers.get("x-forwarded-proto")).toBe("https");
     expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
     expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
+    expect(headers.get("accept-encoding")).toBe("identity");
   });
 
   it("streams the request body with duplex: half", async () => {

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -68,7 +68,10 @@ const handler = async (request: Request, opts: { convexSiteUrl: string }) => {
   headers.delete("transfer-encoding");
   headers.delete("content-length");
   headers.delete("connection");
-  headers.set("accept-encoding", "application/json");
+  // Request uncompressed bodies so the buffered ArrayBuffer matches the
+  // headers we forward (and so stripping content-encoding is safe).
+  // `identity` is already used by getToken() in this module.
+  headers.set("accept-encoding", "identity");
   headers.set("host", new URL(opts.convexSiteUrl).host);
   headers.set("x-forwarded-host", requestUrl.host);
   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
@@ -89,6 +92,10 @@ const handler = async (request: Request, opts: { convexSiteUrl: string }) => {
   // See: get-session / convex/token flakiness with local HTTPS proxies.
   const body = await upstream.arrayBuffer();
   const responseHeaders = new Headers(upstream.headers);
+  // Drop hop-by-hop / encoding headers that must not be re-emitted on a
+  // re-buffered body. With accept-encoding: identity the payload is raw;
+  // content-encoding would otherwise claim compression that is no longer
+  // applied to these bytes.
   responseHeaders.delete("content-encoding");
   responseHeaders.delete("transfer-encoding");
   responseHeaders.delete("connection");

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -59,7 +59,7 @@ const parseConvexSiteUrl = (url: string) => {
   return url;
 };
 
-const handler = (request: Request, opts: { convexSiteUrl: string }) => {
+const handler = async (request: Request, opts: { convexSiteUrl: string }) => {
   const requestUrl = new URL(request.url);
   const nextUrl = `${opts.convexSiteUrl}${requestUrl.pathname}${requestUrl.search}`;
   const headers = new Headers(request.headers);
@@ -74,13 +74,29 @@ const handler = (request: Request, opts: { convexSiteUrl: string }) => {
   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   headers.set("x-better-auth-forwarded-host", requestUrl.host);
   headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
-  return fetch(nextUrl, {
+  const upstream = await fetch(nextUrl, {
     method: request.method,
     headers,
     redirect: "manual",
     body: request.body,
     // @ts-expect-error - duplex is required for streaming request bodies in modern fetch
     duplex: "half",
+  });
+  // Buffer the upstream body before returning. Auth JSON is small, and
+  // streaming an undici fetch body through TanStack Start / Nitro under
+  // inbound `Connection: close` (common with reverse proxies like Portless)
+  // fails roughly every other sequential request with an empty HTTP 400.
+  // See: get-session / convex/token flakiness with local HTTPS proxies.
+  const body = await upstream.arrayBuffer();
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete("content-encoding");
+  responseHeaders.delete("transfer-encoding");
+  responseHeaders.delete("connection");
+  responseHeaders.delete("keep-alive");
+  return new Response(body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
   });
 };
 


### PR DESCRIPTION
## Summary

- Buffer the TanStack Start auth proxy `handler` response body (`arrayBuffer`) instead of streaming the undici `fetch` `Response` through Nitro/srvx.
- Strip hop-by-hop **response** headers when rebuilding the `Response`.
- Keep request hop-by-hop stripping and request body streaming (`duplex: "half"`).
- Add unit coverage for buffered body + header stripping.

Fixes #414

## Why

Under inbound `Connection: close` (common with local reverse proxies such as Portless), streaming an undici fetch body via TanStack Start/Nitro fails roughly every other sequential request with an **empty HTTP 400** that never reaches Convex. Auth payloads are small JSON, so buffering is the right tradeoff.

Related: #356 (request hop-by-hop / undici on Next; suggested buffering for framework handlers).

## Test plan

- [x] `npx vitest run src/react-start/index.test.ts` (5 tests pass)
- [x] Manual: TanStack Start app with stock library handler (no app wrapper)
  - Before: `Connection: close` → `/api/auth/ok|get-session|convex/token` → ~6/12 empty 400
  - After: same paths → 12/12 200; keep-alive 8/8; Portless sequential get-session 12/12
- [ ] CI / maintainer: `npm run test`, `npm run lint`, `npm run typecheck` as preferred

## Notes

Happy to adjust to buffer only GET/HEAD if you prefer that over buffering all methods (POST sign-in responses are still small JSON).