### PR TITLE
fix(cross-domain): don't log a spurious error on callbacks without newSession

### DIFF
--- a/src/plugins/cross-domain/index.ts
+++ b/src/plugins/cross-domain/index.ts
@@ -163,7 +163,12 @@ export const crossDomain = ({ siteUrl }: { siteUrl: string }) => {
             // Mostly copied from the one-time-token plugin
             const session = ctx.context.newSession;
             if (!session) {
-              ctx.context.logger.error("No session found");
+              // No newSession on this callback — e.g. linkSocial, where the
+              // user is already authenticated so no new session is created.
+              // There's nothing to mint a one-time token for, so skip the
+              // handoff. The provider's `location` redirect already set on the
+              // response passes through unchanged; this is an expected path,
+              // not an error.
               return;
             }
             const token = generateRandomString(32);


### PR DESCRIPTION
> Supersedes #389 — that PR got auto-closed when I force-pushed this branch to a bad (parentless) commit by mistake; GitHub won't reopen a PR after a force-push to unrelated history. This is the same branch, fixed: one commit, one file. Original review thread with @erquhart is on #389.

## Problem

The cross-domain after-hook fires on every OAuth / magic-link callback and mints a one-time token from `ctx.context.newSession` for the cross-domain cookie handoff. When the user is already authenticated — e.g. `linkSocial` — no new session is created, so `newSession` is `undefined` and the hook hits:

```ts
if (!session) {
  ctx.context.logger.error("No session found");
  return;
}
```

…logging an error on a completely normal path.

## Change

Drop the `logger.error` on that branch (and document why it's expected). As @erquhart noted on #389, the early `return` doesn't swallow anything: the provider's `location` redirect already set on the response passes through unchanged, so the browser still returns to the app — only the OTT handoff is (correctly) skipped when there's no new session. **No behavioral change.**

## Note

This started as a redirect fix we carried as a prod patch on the 0.10.x line. We've since removed the crossDomain plugin from our own setup, so I can't re-verify the original dead-end against current `better-auth` — going with @erquhart's read that the redirect is preserved on the no-session path, and narrowing this to just the misleading log. Existing `src/plugins/cross-domain/index.test.ts` still passes (6/6).
