### PR TITLE
fix(proxy): stop forwarding x-forwarded-host to the Convex site

### DIFF
--- a/src/nextjs/index.test.ts
+++ b/src/nextjs/index.test.ts
@@ -85,7 +85,9 @@ describe("convexBetterAuthNextJs handler", () => {
       {
         method: "POST",
         body: "{}",
-        headers: { "x-forwarded-host": "app.example.com" },
+        // Deliberately different from the request URL host, so the
+        // assertions below show where each value comes from.
+        headers: { "x-forwarded-host": "proxy.internal.example.com" },
       }
     );
     await handler.POST(request);

--- a/src/nextjs/index.test.ts
+++ b/src/nextjs/index.test.ts
@@ -69,10 +69,29 @@ describe("convexBetterAuthNextJs handler", () => {
     await handler.POST(request);
     const headers = headersOf(fetchSpy);
     expect(headers.get("host")).toBe(new URL(SITE_URL).host);
-    expect(headers.get("x-forwarded-host")).toBe("app.example.com");
+    expect(headers.get("x-forwarded-host")).toBeNull();
     expect(headers.get("x-forwarded-proto")).toBe("https");
     expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
     expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
+  });
+
+  it("drops an inbound x-forwarded-host instead of forwarding it", async () => {
+    const { handler, fetchSpy } = setup();
+    // Platforms in front of the app (Vercel, for one) set this on the way in.
+    // It has to go: Convex's edge routes on it, and an app domain resolves to
+    // no deployment, so the request 404s before the component sees it.
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      {
+        method: "POST",
+        body: "{}",
+        headers: { "x-forwarded-host": "app.example.com" },
+      }
+    );
+    await handler.POST(request);
+    const headers = headersOf(fetchSpy);
+    expect(headers.get("x-forwarded-host")).toBeNull();
+    expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
   });
 
   it("buffers POST body and forwards as ArrayBuffer", async () => {

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -49,15 +49,12 @@ const handler = async (request: Request, siteUrl: string) => {
   headers.delete("transfer-encoding");
   headers.delete("content-length");
   headers.delete("connection");
+  // Convex's edge resolves the deployment from `x-forwarded-host`, so an app
+  // domain here routes to nothing; the component restores it from
+  // `x-better-auth-forwarded-host` instead.
+  headers.delete("x-forwarded-host");
   headers.set("accept-encoding", "application/json");
   headers.set("host", new URL(siteUrl).host);
-  // Convex's edge resolves which deployment serves a request from
-  // `x-forwarded-host` when it is present, so forwarding the app's own domain
-  // routes to no deployment and the request dies as an empty 404 before it
-  // reaches the component. Drop any inbound value as well: platforms such as
-  // Vercel set one on the incoming request. The component restores it from
-  // `x-better-auth-forwarded-host` (see `restoreOriginalForwardedHeaders`).
-  headers.delete("x-forwarded-host");
   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   headers.set("x-better-auth-forwarded-host", requestUrl.host);
   headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -51,7 +51,13 @@ const handler = async (request: Request, siteUrl: string) => {
   headers.delete("connection");
   headers.set("accept-encoding", "application/json");
   headers.set("host", new URL(siteUrl).host);
-  headers.set("x-forwarded-host", requestUrl.host);
+  // Convex's edge resolves which deployment serves a request from
+  // `x-forwarded-host` when it is present, so forwarding the app's own domain
+  // routes to no deployment and the request dies as an empty 404 before it
+  // reaches the component. Drop any inbound value as well: platforms such as
+  // Vercel set one on the incoming request. The component restores it from
+  // `x-better-auth-forwarded-host` (see `restoreOriginalForwardedHeaders`).
+  headers.delete("x-forwarded-host");
   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   headers.set("x-better-auth-forwarded-host", requestUrl.host);
   headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));

--- a/src/react-start/index.test.ts
+++ b/src/react-start/index.test.ts
@@ -87,7 +87,9 @@ describe("convexBetterAuthReactStart handler", () => {
       {
         method: "POST",
         body: "{}",
-        headers: { "x-forwarded-host": "app.example.com" },
+        // Deliberately different from the request URL host, so the
+        // assertions below show where each value comes from.
+        headers: { "x-forwarded-host": "proxy.internal.example.com" },
       }
     );
     await handler(request);

--- a/src/react-start/index.test.ts
+++ b/src/react-start/index.test.ts
@@ -71,10 +71,29 @@ describe("convexBetterAuthReactStart handler", () => {
     await handler(request);
     const headers = headersOf(fetchSpy);
     expect(headers.get("host")).toBe(new URL(SITE_URL).host);
-    expect(headers.get("x-forwarded-host")).toBe("app.example.com");
+    expect(headers.get("x-forwarded-host")).toBeNull();
     expect(headers.get("x-forwarded-proto")).toBe("https");
     expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
     expect(headers.get("x-better-auth-forwarded-proto")).toBe("https");
+  });
+
+  it("drops an inbound x-forwarded-host instead of forwarding it", async () => {
+    const { handler, fetchSpy } = setup();
+    // Platforms in front of the app (Vercel, for one) set this on the way in.
+    // It has to go: Convex's edge routes on it, and an app domain resolves to
+    // no deployment, so the request 404s before the component sees it.
+    const request = new Request(
+      "https://app.example.com/api/auth/sign-in/email",
+      {
+        method: "POST",
+        body: "{}",
+        headers: { "x-forwarded-host": "app.example.com" },
+      }
+    );
+    await handler(request);
+    const headers = headersOf(fetchSpy);
+    expect(headers.get("x-forwarded-host")).toBeNull();
+    expect(headers.get("x-better-auth-forwarded-host")).toBe("app.example.com");
   });
 
   it("streams the request body with duplex: half", async () => {

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -70,7 +70,13 @@ const handler = (request: Request, opts: { convexSiteUrl: string }) => {
   headers.delete("connection");
   headers.set("accept-encoding", "application/json");
   headers.set("host", new URL(opts.convexSiteUrl).host);
-  headers.set("x-forwarded-host", requestUrl.host);
+  // Convex's edge resolves which deployment serves a request from
+  // `x-forwarded-host` when it is present, so forwarding the app's own domain
+  // routes to no deployment and the request dies as an empty 404 before it
+  // reaches the component. Drop any inbound value as well: platforms such as
+  // Vercel set one on the incoming request. The component restores it from
+  // `x-better-auth-forwarded-host` (see `restoreOriginalForwardedHeaders`).
+  headers.delete("x-forwarded-host");
   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   headers.set("x-better-auth-forwarded-host", requestUrl.host);
   headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -68,15 +68,12 @@ const handler = (request: Request, opts: { convexSiteUrl: string }) => {
   headers.delete("transfer-encoding");
   headers.delete("content-length");
   headers.delete("connection");
+  // Convex's edge resolves the deployment from `x-forwarded-host`, so an app
+  // domain here routes to nothing; the component restores it from
+  // `x-better-auth-forwarded-host` instead.
+  headers.delete("x-forwarded-host");
   headers.set("accept-encoding", "application/json");
   headers.set("host", new URL(opts.convexSiteUrl).host);
-  // Convex's edge resolves which deployment serves a request from
-  // `x-forwarded-host` when it is present, so forwarding the app's own domain
-  // routes to no deployment and the request dies as an empty 404 before it
-  // reaches the component. Drop any inbound value as well: platforms such as
-  // Vercel set one on the incoming request. The component restores it from
-  // `x-better-auth-forwarded-host` (see `restoreOriginalForwardedHeaders`).
-  headers.delete("x-forwarded-host");
   headers.set("x-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));
   headers.set("x-better-auth-forwarded-host", requestUrl.host);
   headers.set("x-better-auth-forwarded-proto", requestUrl.protocol.replace(/:$/, ""));

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getToken } from "./index.js";
+
+const SITE_URL = "https://test.convex.site";
+
+describe("getToken", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not send x-forwarded-host to the Convex site", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ token: "jwt" }), {
+        headers: { "content-type": "application/json" },
+      })
+    );
+    // Callers hand over the inbound request headers, and hosting platforms put
+    // the app's own domain in `x-forwarded-host` on the way in. Convex's edge
+    // routes on it, so it has to be dropped alongside the host rewrite.
+    const headers = new Headers({ "x-forwarded-host": "app.example.com" });
+
+    await getToken(SITE_URL, headers);
+
+    expect(headers.get("x-forwarded-host")).toBeNull();
+    expect(headers.get("host")).toBe(new URL(SITE_URL).host);
+    const sent = new Headers(
+      (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.headers
+    );
+    expect(sent.get("x-forwarded-host")).toBeNull();
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -138,6 +138,11 @@ export const getToken = async (
   opts?: GetTokenOptions
 ) => {
   headers.set("host", new URL(siteUrl).host);
+  // Callers pass the inbound request headers straight through, and hosting
+  // platforms set `x-forwarded-host` on the way in. Convex's edge resolves
+  // the deployment from it, so leaving the app domain there 404s the token
+  // request and server-side auth reports the user as signed out.
+  headers.delete("x-forwarded-host");
   const fetchToken = async () => {
     const basePath = opts?.basePath
       ? (opts.basePath.startsWith("/")


### PR DESCRIPTION
Fixes #422.

## The problem

Convex's edge resolves which deployment serves a request from `x-forwarded-host` when that header is present. Anything that sends the **app's own domain** in it resolves to no deployment, so the request dies as an **empty 404** at the edge (`convex-usher: usher`, no body) before the component ever runs.

There are two paths that do it.

**1. The framework proxies.** `src/nextjs/index.ts` and `src/react-start/index.ts` set it explicitly:

```js
headers.set("host", new URL(siteUrl).host);
headers.set("x-forwarded-host", requestUrl.host);   // ← app host
```

Every `/api/auth/*` route is dead for any app served from its own domain.

**2. The server-side token path.** Both adapters hand `getToken` the inbound request headers verbatim:

```js
const headers = await (await import("next/headers.js")).headers();
const mutableHeaders = new Headers(headers);
return getToken(siteUrl, mutableHeaders, ...);
```

Hosting platforms set `x-forwarded-host` on that inbound request, so the copy carries the app domain to `/api/auth/convex/token` and it 404s the same way. `isAuthenticated()` and `getToken()` then report the user as signed out while the client session cookie is perfectly valid. Reported by @aguilaair on #422; the first revision of this PR missed it.

Sessions already issued keep working, so nothing looks wrong until someone signs in on a new device, accepts an invite, or hits a server-rendered page.

## Why removing it is safe

Sending it was redundant. `restoreOriginalForwardedHeaders` in `src/client/create-client.ts` already rebuilds `x-forwarded-host` **inside the component**, from `x-better-auth-forwarded-host`, immediately before `auth.handler`:

```ts
const originalHost = request.headers.get("x-better-auth-forwarded-host");
...
headers.set("x-forwarded-host", originalHost);
```

That header pair exists precisely to carry the public origin past intermediaries that would otherwise act on it. The edge is one such intermediary.

Stronger still: the value the proxy sent was already being **overwritten**, and there is a test in this repo that says so. `src/client/create-client.test.ts` feeds the handler an inbound `x-forwarded-host: deployment.convex.site` alongside `x-better-auth-forwarded-host: app.example.com`, and asserts the request reaching Better Auth carries `app.example.com`. Whatever the proxy put on the wire never survived. Removing it is provably behaviour-neutral from Better Auth's point of view, and only changes what the edge sees.

## The change

- `src/nextjs/index.ts` and `src/react-start/index.ts`: **delete** the header rather than merely not setting it, since platforms in front of the app set one on the incoming request.
- `src/utils/index.ts`: same delete beside the existing `host` rewrite in `getToken`, which covers every caller at once. Both adapters route through this helper, so Next.js and react-start SSR are both fixed by the one line.

`x-forwarded-proto` is left alone: it traverses the edge without issue, and the component restores it too.

## Tests

- The existing "sets host and forwarding headers" test in each adapter now asserts the header is absent.
- A new test per adapter covers the inbound case, using a proxy host distinct from the request URL host so the assertions show where each value comes from.
- New `src/utils/index.test.ts` covers the `getToken` path.

Per the developing guide:

```
rm -rf dist/ && npm run build   ✔
npm run typecheck               ✔ no new errors
npm run test                    ✔ 185 passed | 31 skipped, no type errors
```

`npm run typecheck` reports 53 errors, all module-resolution failures under `examples/next/` from that workspace's dependencies not being installed. Identical count on a clean checkout with the change stashed, and none outside `examples/`.

## Verified against live deployments

| Header on `GET <deployment>.convex.site/api/auth/ok` | Status |
| --- | --- |
| *(none)* | 200 |
| `x-forwarded-host: app.example.com` | **404** |
| `x-forwarded-host: <deployment>.convex.site` | 200 |
| `x-better-auth-forwarded-host: app.example.com` | 200 |
| `x-forwarded-proto: https` | 200 |

An equivalent local patch is running in our production app. `POST /api/auth/sign-in/email` went from an empty 404 to `401 {"code":"INVALID_EMAIL_OR_PASSWORD"}`, and sign-in works again.

## A note on how this was written

I used an AI assistant while investigating and drafting this. The diagnosis was reproduced by hand against real deployments, and I have read and understood every line of the change and the tests before opening this. Happy to adjust anything.
