### PR TITLE
fix: match unset optional fields against null where clauses

### DIFF
--- a/src/client/adapter-utils.ts
+++ b/src/client/adapter-utils.ts
@@ -339,11 +339,12 @@ const filterByWhere = <
       }
       return val > wVal;
     };
+    const isNullish = (val: typeof value) => val === undefined || val === null;
     const filter = (w: Infer<typeof adapterWhereValidator>) => {
       switch (w.operator) {
         case undefined:
         case "eq": {
-          return value === w.value;
+          return w.value === null ? isNullish(value) : value === w.value;
         }
         case "in": {
           return Array.isArray(w.value) && (w.value as any[]).includes(value);
@@ -366,7 +367,7 @@ const filterByWhere = <
           return value === w.value || isGreaterThan(value, w.value);
         }
         case "ne": {
-          return value !== w.value;
+          return w.value === null ? !isNullish(value) : value !== w.value;
         }
         case "contains": {
           return typeof value === "string" && value.includes(w.value as string);

--- a/src/test/adapter-factory/convex-custom.ts
+++ b/src/test/adapter-factory/convex-custom.ts
@@ -728,6 +728,205 @@ export const convexCustomTestSuite = createTestSuite(
       ).toEqual(nonNullRangeAccount);
     },
 
+    "should match unset optional fields against eq null": async () => {
+      const now = Date.now();
+      // Convex omits optional fields that were never written, while every
+      // other first-party adapter matches them against `eq null` (SQL `IS
+      // NULL`, Mongo `{ field: null }`). @better-auth/oauth-provider relies on
+      // it: refresh tokens are created with no `revoked` key, then rotated
+      // with an `eq null` compare-and-swap.
+      const unsetAccountId = `eq-null-${now}-unset`;
+      const explicitNullAccountId = `eq-null-${now}-explicit-null`;
+      const nonNullAccountId = `eq-null-${now}-non-null`;
+
+      // created with no accessTokenExpiresAt key at all
+      const unsetAccount = await adapter.create({
+        model: "account",
+        data: {
+          accountId: unsetAccountId,
+          providerId: "eq-null-provider",
+          userId: `eq-null-user-${now}`,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      const explicitNullAccount = await adapter.create({
+        model: "account",
+        data: {
+          accountId: explicitNullAccountId,
+          providerId: "eq-null-provider",
+          userId: `eq-null-user-${now}`,
+          accessTokenExpiresAt: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      await adapter.create({
+        model: "account",
+        data: {
+          accountId: nonNullAccountId,
+          providerId: "eq-null-provider",
+          userId: `eq-null-user-${now}`,
+          accessTokenExpiresAt: now + 1_000,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      expect(
+        await adapter.findOne({
+          model: "account",
+          where: [
+            {
+              field: "accessTokenExpiresAt",
+              operator: "eq",
+              connector: "AND",
+              value: null,
+            },
+            {
+              field: "accountId",
+              operator: "eq",
+              connector: "AND",
+              value: unsetAccountId,
+            },
+          ],
+        }),
+      ).toEqual(unsetAccount);
+
+      // the shape core's incrementOne fallback issues for the compare-and-swap
+      expect(
+        await adapter.findMany({
+          model: "account",
+          where: [
+            {
+              field: "id",
+              operator: "eq",
+              connector: "AND",
+              value: unsetAccount.id,
+            },
+            {
+              field: "accessTokenExpiresAt",
+              operator: "eq",
+              connector: "AND",
+              value: null,
+            },
+          ],
+          limit: 1,
+        }),
+      ).toEqual([unsetAccount]);
+
+      expect(
+        await adapter.findOne({
+          model: "account",
+          where: [
+            {
+              field: "accessTokenExpiresAt",
+              operator: "eq",
+              connector: "AND",
+              value: null,
+            },
+            {
+              field: "accountId",
+              operator: "eq",
+              connector: "AND",
+              value: explicitNullAccountId,
+            },
+          ],
+        }),
+      ).toEqual(explicitNullAccount);
+
+      expect(
+        await adapter.findOne({
+          model: "account",
+          where: [
+            {
+              field: "accessTokenExpiresAt",
+              operator: "eq",
+              connector: "AND",
+              value: null,
+            },
+            {
+              field: "accountId",
+              operator: "eq",
+              connector: "AND",
+              value: nonNullAccountId,
+            },
+          ],
+        }),
+      ).toEqual(null);
+    },
+
+    "should not match unset optional fields against ne null": async () => {
+      const now = Date.now();
+      const unsetAccountId = `ne-null-${now}-unset`;
+      const nonNullAccountId = `ne-null-${now}-non-null`;
+
+      await adapter.create({
+        model: "account",
+        data: {
+          accountId: unsetAccountId,
+          providerId: "ne-null-provider",
+          userId: `ne-null-user-${now}`,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      const nonNullAccount = await adapter.create({
+        model: "account",
+        data: {
+          accountId: nonNullAccountId,
+          providerId: "ne-null-provider",
+          userId: `ne-null-user-${now}`,
+          accessTokenExpiresAt: now + 1_000,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      expect(
+        await adapter.findOne({
+          model: "account",
+          where: [
+            {
+              field: "accessTokenExpiresAt",
+              operator: "ne",
+              connector: "AND",
+              value: null,
+            },
+            {
+              field: "accountId",
+              operator: "eq",
+              connector: "AND",
+              value: unsetAccountId,
+            },
+          ],
+        }),
+      ).toEqual(null);
+
+      expect(
+        await adapter.findOne({
+          model: "account",
+          where: [
+            {
+              field: "accessTokenExpiresAt",
+              operator: "ne",
+              connector: "AND",
+              value: null,
+            },
+            {
+              field: "accountId",
+              operator: "eq",
+              connector: "AND",
+              value: nonNullAccountId,
+            },
+          ],
+        }),
+      ).toEqual(nonNullAccount);
+    },
+
     "should fail to create a record with a unique field that already exists":
       async () => {
         await adapter.create({


### PR DESCRIPTION
Closes #399.

## Problem

`filterByWhere` implemented `eq` as strict equality (`value === w.value`). Convex omits optional fields that were never written, so such a field reads back as `undefined` and never matched `eq null`. Every other first-party adapter treats an unset optional field as matching — SQL `IS NULL`, Mongo `{ field: null }` — so plugins written against that contract broke only here. `adapterWhereValidator` already accepts `v.null()` for `value`, so the input was supported; nothing handled it for `eq`/`ne`.

**Impact:** `@better-auth/oauth-provider` creates `oauthRefreshToken` rows with no `revoked` key, then guards rotation with a CAS on `[{ field: "id" }, { field: "revoked", operator: "eq", value: null }]`. With no native `incrementOne`, core falls back to `findMany({ where, limit: 1 })`; the `revoked eq null` leg never matched the fresh row, so **every `refresh_token` grant failed with 400 `invalid_grant`**, making `offline_access` unusable. Device-authorization uses the same create-without-the-field-then-match-`eq null` pattern with `userId`.

## Fix

Treat an absent field as null when the where value is null, for `eq` and the mirrored `ne`. This follows the local-predicate pattern already in `filterByWhere` — `isLessThan` for `lt`/`lte`, `isGreaterThan` for `gt`/`gte`, now `isNullish` for `eq`/`ne`; both existing helpers already coalesce `null` and `undefined` the same way. Behavior changes only when the where value is `null`.

## Tests

Two cases in `convexCustomTestSuite`, beside the existing `should preserve null to non-null range comparisons`:

- `should match unset optional fields against eq null` — an `account` created with no `accessTokenExpiresAt` key matches via `findOne` and via the `findMany` shape core's `incrementOne` fallback issues; an explicitly-null field still matches; a field with a value does not.
- `should not match unset optional fields against ne null` — the mirror.

`account.accessTokenExpiresAt` is an unindexed nullable timestamp, the same shape as `revoked`, so the clause is applied as a static filter rather than pushed into an index range. Without the fix these two are the only failures in the adapter suite (`2 failed | 131 passed`); with it, `133 passed`.

Upstream `@better-auth/test-utils` null coverage (`eq operator with null value (single condition) should use IS NULL`, the AND/OR group variants, `update — ... where condition uses null value`) passes both before and after this change — it exercises *explicitly written* nulls; the gap was only fields Convex omits.

## Known gap (pre-existing, not addressed here)

A null-valued `eq` on an *indexed* field is pushed into the index range instead, and Convex index ranges match only explicit nulls:

```ts
// two user docs: one with username absent, one with username: null
await ctx.db.query("user").withIndex("username", (q) => q.eq("username", null)).collect();
// → only the explicitly-null doc
```

Closing it means truncating the index range at the first null-valued `eq` and re-applying it (and everything after) statically, which also touches `paginate`'s unique short-circuit. That felt separate from this fix, and it isn't needed for #399: `revoked` is unindexed and the rotation CAS goes through the `_id` short-circuit, both landing in `filterByWhere`. Happy to fold it in if you'd prefer. `in`/`not_in` share the same asymmetry and are likewise unchanged.

## Verification

On Node 24 (`src/client/adapter.test.ts` self-skips below it): `npm test` — 184 passed, 31 skipped, no type errors · `npm run typecheck` — clean, including all example projects · `npm run lint` — 0 errors (3 pre-existing `react-hooks/exhaustive-deps` warnings in `src/react/index.tsx`) · `npm run build` — clean.
