### PR TITLE
fix: parse static JWKS dates so multi-key deployments can sign tokens

### DIFF
--- a/src/plugins/convex/index.test.ts
+++ b/src/plugins/convex/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { betterAuth } from "better-auth/minimal";
+import type { BetterAuthOptions } from "better-auth/minimal";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import type { MemoryDB } from "better-auth/adapters/memory";
 import type { AuthConfig } from "convex/server";
 import { convex } from "./index.js";
+import { getAuthConfigProvider } from "../../auth-config.js";
 
 const authConfig = {
   providers: [{ applicationID: "convex", domain: "https://example.com" }],
@@ -51,5 +56,109 @@ describe("convex plugin JWT cookie refresh matcher", () => {
     };
     expect(matcher(withSessionCtx as unknown as MatcherContext)).toBe(true);
     expect(matcher(withoutSessionCtx as unknown as MatcherContext)).toBe(false);
+  });
+});
+
+const AUTH_BASE_URL = "https://example.com";
+const BASE_PATH = "/api/auth";
+
+process.env.CONVEX_SITE_URL = "https://example.convex.site";
+
+const emptyDb = (): MemoryDB => ({
+  user: [],
+  session: [],
+  account: [],
+  verification: [],
+  jwks: [],
+});
+
+const mutationCtxDatabase = (db: MemoryDB) => (options: BetterAuthOptions) => {
+  const adapter = memoryAdapter(db)(options);
+  return {
+    ...adapter,
+    options: { ...(adapter.options ?? {}), isRunMutationCtx: true },
+  };
+};
+
+const makeAuth = (db: MemoryDB, jwks?: string) =>
+  betterAuth({
+    baseURL: AUTH_BASE_URL,
+    basePath: BASE_PATH,
+    secret: "test-secret-at-least-thirty-two-characters-long",
+    database: mutationCtxDatabase(db),
+    emailAndPassword: { enabled: true },
+    plugins: [
+      convex({
+        authConfig: {
+          providers: [getAuthConfigProvider(jwks ? { jwks } : undefined)],
+        },
+        ...(jwks ? { jwks } : {}),
+      }),
+    ],
+  });
+
+const request = (
+  auth: ReturnType<typeof makeAuth>,
+  path: string,
+  init?: RequestInit
+) => auth.handler(new Request(`${AUTH_BASE_URL}${BASE_PATH}${path}`, init));
+
+const signUp = async (auth: ReturnType<typeof makeAuth>) => {
+  const res = await request(auth, "/sign-up/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email: "test@example.com",
+      password: "testpassword123",
+      name: "Test User",
+    }),
+  });
+  expect(res.status).toBe(200);
+  const setCookies = res.headers.getSetCookie();
+  return {
+    setCookies,
+    cookie: setCookies.map((c) => c.split(";")[0]).join("; "),
+  };
+};
+
+const mintKey = async () => {
+  const db = emptyDb();
+  const res = await request(makeAuth(db), "/convex/jwks");
+  expect(res.status).toBe(200);
+  return db.jwks[0];
+};
+
+const kidOf = (token: string) =>
+  JSON.parse(
+    new TextDecoder().decode(Buffer.from(token.split(".")[0], "base64url"))
+  ).kid;
+
+describe("convex plugin static JWKS", async () => {
+  const [firstKey, secondKey] = await Promise.all([mintKey(), mintKey()]);
+  const older = { ...firstKey, createdAt: 1_700_000_000_000 };
+  const newer = { ...secondKey, createdAt: 1_700_000_000_090 };
+
+  it("issues a token with a single key", async () => {
+    const auth = makeAuth(emptyDb(), JSON.stringify([newer]));
+    const { cookie } = await signUp(auth);
+    const res = await request(auth, "/convex/token", { headers: { cookie } });
+    expect(res.status).toBe(200);
+  });
+
+  it("issues a token signed by the newest key with multiple keys", async () => {
+    const auth = makeAuth(emptyDb(), JSON.stringify([older, newer]));
+    const { cookie, setCookies } = await signUp(auth);
+    const res = await request(auth, "/convex/token", { headers: { cookie } });
+    expect(res.status).toBe(200);
+    expect(kidOf((await res.json()).token)).toBe(newer.id);
+    expect(setCookies.some((c) => c.includes("convex_jwt="))).toBe(true);
+  });
+
+  it("serves the jwks endpoint for a key with expiresAt", async () => {
+    const jwks = JSON.stringify([
+      { ...newer, expiresAt: 1_700_000_086_400_000 },
+    ]);
+    const res = await request(makeAuth(emptyDb(), jwks), "/convex/jwks");
+    expect(res.status).toBe(200);
   });
 });

--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -39,6 +39,12 @@ const getJwksAlg = (authProvider: AuthProvider) => {
   return isCustomJwt ? authProvider.algorithm : "EdDSA";
 };
 
+const parseJwkDates = (key: Jwk): Jwk => ({
+  ...key,
+  createdAt: new Date(key.createdAt),
+  ...(key.expiresAt ? { expiresAt: new Date(key.expiresAt) } : {}),
+});
+
 const parseAuthConfig = (authConfig: AuthConfig, opts: { jwks?: string }) => {
   const providerConfigs = authConfig.providers.filter(
     (provider) => provider.applicationID === "convex"
@@ -205,7 +211,9 @@ export const convex = (opts: {
       },
     },
   } satisfies JwtOptions;
-  const jwks = opts.jwks ? JSON.parse(opts.jwks) : undefined;
+  const jwks: Jwk[] | undefined = opts.jwks
+    ? JSON.parse(opts.jwks).map(parseJwkDates)
+    : undefined;
   const jwt = jwtPlugin({
     ...jwtOptions,
     adapter: {
@@ -223,8 +231,8 @@ export const convex = (opts: {
         });
       },
       getJwks: async (ctx) => {
-        if (opts.jwks) {
-          return jwks;
+        if (jwks) {
+          return [...jwks];
         }
         // TODO: remove when date parsing for jwks adapter is fixed upstream
         const keys: Jwk[] = await ctx.context.adapter.findMany<Jwk>({
@@ -234,11 +242,7 @@ export const convex = (opts: {
             direction: "desc",
           },
         });
-        return keys.map((key) => ({
-          ...key,
-          createdAt: new Date(key.createdAt),
-          ...(key.expiresAt ? { expiresAt: new Date(key.expiresAt) } : {}),
-        }));
+        return keys.map(parseJwkDates);
       },
     },
   });


### PR DESCRIPTION
Fixes #427. Diagnosis and the original patch are @Misophistful's — opening the PR at their suggestion.

### Problem

The static JWKS branch of the jwt adapter returned `JSON.parse` output as-is, so `createdAt` stayed the epoch millis the Convex adapter stores (`JwksDoc` in `src/auth-config.ts` types it as `number`). Better Auth's `getLatestKey` sorts with `b.createdAt.getTime()`, and `Array.prototype.sort` never calls the comparator on a single-element array — so a one-key deployment works and any deployment holding two or more keys returns 500 from `/api/auth/convex/token`:

```
TypeError: b.createdAt.getTime is not a function
```

It's easy to miss because the documented bootstrap (`auth:getLatestJwks`) uses `limit: 1`, so the value it produces contains exactly one key. The failure only arrives later, after a rotation or when two concurrent requests each mint a key.

Two extra symptoms worth noting:

- `expiresAt` has the same problem and needs only **one** key. The jwks handler filters on `key.expiresAt.getTime()`, so a static JWKS carrying an `expiresAt` 500s `/api/auth/convex/jwks` outright.
- It also fails silently at sign-in. The after hook that sets the `convex_jwt` cookie swallows token errors, so sign-in still returns 200, just with no JWT cookie.

### Fix

Map the dates once where the env var is parsed, rather than on every `getJwks` call, and share the helper with the adapter branch below it — that branch was already doing this conversion inline, which is how the two drifted apart. Unlike the adapter branch's `TODO`, this one isn't waiting on an upstream change: `JSON.parse` can't produce a `Date`.

The static branch returns a copy because `getLatestKey` sorts the returned array in place, which would otherwise reorder the cached one and change the key order served by `/convex/jwks` after the first token is signed. Harmless in itself since keys are looked up by `kid`, but not worth leaving in.

### Verification

Added regression coverage to `src/plugins/convex/index.test.ts` driving a real `betterAuth()` instance over the documented static setup — real minted RS256 keys, `GET /api/auth/convex/token` through the actual handler.

| Case | before | after |
| --- | --- | --- |
| 1 key → `/convex/token` | 200 | 200 |
| 2 keys → `/convex/token` | 500 | 200 |
| 1 key with `expiresAt` → `/convex/jwks` | 500 | 200 |

The multi-key test also asserts the newest key is the one that signs (`kid`), and that the `convex_jwt` cookie is set at sign-in. Both new tests fail on `main` and pass with this change; the single-key test passes either way, documenting the masking.

Checked out of tree as well, not included here: the same flow against the real Convex adapter via `convexTest` (500 before, 200 after, `getLatestJwks` confirmed to return `createdAt` as a number), and a five-key set in scrambled order where the newest key signs, an expired key is filtered from `/convex/jwks`, and `expiresAt: null` — which the component schema permits — is handled.

`npm run build`, `npm run test`, `npm run typecheck` and `npm run lint` are clean on Node 22 and on Node 24 (187 passed / 31 skipped on 24, matching CI).
