### PR TITLE
fix(react): preserve auth during SSR hydration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/node": "24.12.3",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
+        "@types/react-test-renderer": "19.1.0",
         "@types/semver": "7.7.1",
         "better-auth": "1.6.15",
         "chokidar-cli": "3.0.0",
@@ -47,6 +48,7 @@
         "prettier": "3.8.3",
         "react": "19.2.6",
         "react-dom": "19.2.6",
+        "react-test-renderer": "19.2.6",
         "typescript": "5.9.3",
         "typescript-eslint": "8.59.2",
         "vitest": "4.1.5"
@@ -3085,6 +3087,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -7684,6 +7696,27 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.6.tgz",
+      "integrity": "sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.6",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@types/node": "24.12.3",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@types/react-test-renderer": "19.1.0",
     "@types/semver": "7.7.1",
     "better-auth": "1.6.15",
     "chokidar-cli": "3.0.0",
@@ -134,6 +135,7 @@
     "prettier": "3.8.3",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "react-test-renderer": "19.2.6",
     "typescript": "5.9.3",
     "typescript-eslint": "8.59.2",
     "vitest": "4.1.5"

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -1,0 +1,92 @@
+import { act, create } from "react-test-renderer";
+import type { ReactTestRenderer } from "react-test-renderer";
+import { describe, expect, test, vi } from "vitest";
+
+import { ConvexBetterAuthProvider } from "./index.js";
+import type { AuthClient } from "./index.js";
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ConvexBetterAuthProvider", () => {
+  test("keeps auth set during SSR hydration and rotates it for a new session", async () => {
+    let sessionState: {
+      data: { session: { id: string } } | null;
+      isPending: boolean;
+    } = { data: null, isPending: true };
+    const token = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { token: "fresh-token" } })
+      .mockResolvedValueOnce({ data: { token: "replacement-token" } });
+    const authClient = {
+      convex: { token },
+      useSession: () => sessionState,
+    } as unknown as AuthClient;
+    const client = {
+      clearAuth: vi.fn(),
+      setAuth: vi.fn(),
+    };
+    const renderProvider = () => (
+      <ConvexBetterAuthProvider
+        authClient={authClient}
+        client={client}
+        initialToken="server-token"
+      >
+        <div />
+      </ConvexBetterAuthProvider>
+    );
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(renderProvider());
+    });
+
+    expect(client.setAuth).toHaveBeenCalledTimes(1);
+    const initialFetchToken = client.setAuth.mock.calls[0]?.[0];
+    await expect(
+      initialFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("server-token");
+    await act(async () => {
+      await expect(
+        initialFetchToken?.({ forceRefreshToken: true })
+      ).resolves.toBe("fresh-token");
+    });
+    await expect(
+      initialFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("fresh-token");
+    expect(token).toHaveBeenCalledTimes(1);
+
+    sessionState = {
+      data: { session: { id: "session-a" } },
+      isPending: false,
+    };
+    await act(async () => {
+      renderer.update(renderProvider());
+    });
+
+    expect(client.clearAuth).not.toHaveBeenCalled();
+    expect(client.setAuth).toHaveBeenCalledTimes(1);
+
+    sessionState = {
+      data: { session: { id: "session-b" } },
+      isPending: false,
+    };
+    await act(async () => {
+      renderer.update(renderProvider());
+    });
+
+    expect(client.clearAuth).toHaveBeenCalledTimes(1);
+    expect(client.setAuth).toHaveBeenCalledTimes(2);
+    const replacementFetchToken = client.setAuth.mock.calls[1]?.[0];
+    expect(replacementFetchToken).not.toBe(initialFetchToken);
+    await expect(
+      replacementFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("replacement-token");
+    expect(token).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -9,32 +9,68 @@ import type { AuthClient } from "./index.js";
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+function createSessionToken(sessionId: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "none" })).toString(
+    "base64url"
+  );
+  const payload = Buffer.from(JSON.stringify({ sessionId })).toString(
+    "base64url"
+  );
+  return `${header}.${payload}.signature`;
+}
+
 describe("ConvexBetterAuthProvider", () => {
-  test("keeps auth set during SSR hydration and rotates it for a new session", async () => {
+  test("preserves matching SSR auth and rejects a different hydrated session", async () => {
     let sessionState: {
       data: { session: { id: string } } | null;
       isPending: boolean;
     } = { data: null, isPending: true };
+    let mismatchedSessionState: {
+      data: { session: { id: string } } | null;
+      isPending: boolean;
+    } = { data: null, isPending: true };
+    const serverToken = createSessionToken("session-a");
+    const mismatchedServerToken = createSessionToken("session-a");
     const token = vi
       .fn()
       .mockResolvedValueOnce({ data: { token: "fresh-token" } })
       .mockResolvedValueOnce({ data: { token: "replacement-token" } });
+    const mismatchedToken = vi
+      .fn()
+      .mockResolvedValue({ data: { token: "session-b-token" } });
     const authClient = {
       convex: { token },
       useSession: () => sessionState,
+    } as unknown as AuthClient;
+    const mismatchedAuthClient = {
+      convex: { token: mismatchedToken },
+      useSession: () => mismatchedSessionState,
     } as unknown as AuthClient;
     const client = {
       clearAuth: vi.fn(),
       setAuth: vi.fn(),
     };
+    const mismatchedClient = {
+      clearAuth: vi.fn(),
+      setAuth: vi.fn(),
+    };
     const renderProvider = () => (
-      <ConvexBetterAuthProvider
-        authClient={authClient}
-        client={client}
-        initialToken="server-token"
-      >
-        <div />
-      </ConvexBetterAuthProvider>
+      <>
+        <ConvexBetterAuthProvider
+          authClient={authClient}
+          client={client}
+          initialToken={serverToken}
+        >
+          <div />
+        </ConvexBetterAuthProvider>
+        <ConvexBetterAuthProvider
+          authClient={mismatchedAuthClient}
+          client={mismatchedClient}
+          initialToken={mismatchedServerToken}
+        >
+          <div />
+        </ConvexBetterAuthProvider>
+      </>
     );
 
     let renderer: ReactTestRenderer;
@@ -46,16 +82,13 @@ describe("ConvexBetterAuthProvider", () => {
     const initialFetchToken = client.setAuth.mock.calls[0]?.[0];
     await expect(
       initialFetchToken?.({ forceRefreshToken: false })
-    ).resolves.toBe("server-token");
-    await act(async () => {
-      await expect(
-        initialFetchToken?.({ forceRefreshToken: true })
-      ).resolves.toBe("fresh-token");
-    });
+    ).resolves.toBe(serverToken);
+    expect(mismatchedClient.setAuth).toHaveBeenCalledTimes(1);
+    const mismatchedInitialFetchToken =
+      mismatchedClient.setAuth.mock.calls[0]?.[0];
     await expect(
-      initialFetchToken?.({ forceRefreshToken: false })
-    ).resolves.toBe("fresh-token");
-    expect(token).toHaveBeenCalledTimes(1);
+      mismatchedInitialFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe(mismatchedServerToken);
 
     sessionState = {
       data: { session: { id: "session-a" } },
@@ -67,6 +100,39 @@ describe("ConvexBetterAuthProvider", () => {
 
     expect(client.clearAuth).not.toHaveBeenCalled();
     expect(client.setAuth).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await expect(
+        initialFetchToken?.({ forceRefreshToken: true })
+      ).resolves.toBe("fresh-token");
+    });
+    await expect(
+      initialFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("fresh-token");
+    expect(token).toHaveBeenCalledTimes(1);
+
+    mismatchedSessionState = {
+      data: { session: { id: "session-b" } },
+      isPending: false,
+    };
+    await act(async () => {
+      renderer.update(renderProvider());
+    });
+
+    expect(mismatchedClient.clearAuth).toHaveBeenCalledTimes(1);
+    expect(mismatchedClient.setAuth).toHaveBeenCalledTimes(2);
+    const mismatchedReplacementFetchToken =
+      mismatchedClient.setAuth.mock.calls[1]?.[0];
+    expect(mismatchedReplacementFetchToken).not.toBe(
+      mismatchedInitialFetchToken
+    );
+    await expect(
+      mismatchedInitialFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("session-b-token");
+    await expect(
+      mismatchedReplacementFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("session-b-token");
+    expect(mismatchedToken).toHaveBeenCalledTimes(1);
 
     sessionState = {
       data: { session: { id: "session-b" } },

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -89,4 +89,81 @@ describe("ConvexBetterAuthProvider", () => {
       renderer.unmount();
     });
   });
+
+  test("does not reuse or cache a pending token from a replaced session", async () => {
+    let sessionState: {
+      data: { session: { id: string } } | null;
+      isPending: boolean;
+    } = {
+      data: { session: { id: "session-a" } },
+      isPending: false,
+    };
+    let resolveSessionAToken!: (value: { data: { token: string } }) => void;
+    const sessionATokenRequest = new Promise<{ data: { token: string } }>(
+      (resolve) => {
+        resolveSessionAToken = resolve;
+      }
+    );
+    const token = vi
+      .fn()
+      .mockReturnValueOnce(sessionATokenRequest)
+      .mockResolvedValueOnce({ data: { token: "session-b-token" } });
+    const authClient = {
+      convex: { token },
+      useSession: () => sessionState,
+    } as unknown as AuthClient;
+    const client = {
+      clearAuth: vi.fn(),
+      setAuth: vi.fn(),
+    };
+    const renderProvider = () => (
+      <ConvexBetterAuthProvider authClient={authClient} client={client}>
+        <div />
+      </ConvexBetterAuthProvider>
+    );
+
+    let renderer: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(renderProvider());
+    });
+
+    const sessionAFetchToken = client.setAuth.mock.calls[0]?.[0];
+    const staleTokenPromise = sessionAFetchToken?.({
+      forceRefreshToken: false,
+    });
+    expect(token).toHaveBeenCalledTimes(1);
+
+    sessionState = {
+      data: { session: { id: "session-b" } },
+      isPending: false,
+    };
+    await act(async () => {
+      renderer.update(renderProvider());
+    });
+
+    expect(client.clearAuth).toHaveBeenCalledTimes(1);
+    expect(client.setAuth).toHaveBeenCalledTimes(2);
+    const sessionBFetchToken = client.setAuth.mock.calls[1]?.[0];
+    await act(async () => {
+      await expect(
+        sessionBFetchToken?.({ forceRefreshToken: false })
+      ).resolves.toBe("session-b-token");
+    });
+
+    let staleToken: string | null | undefined;
+    await act(async () => {
+      resolveSessionAToken({ data: { token: "session-a-token" } });
+      staleToken = await staleTokenPromise;
+    });
+
+    expect(staleToken).toBeNull();
+    await expect(
+      sessionBFetchToken?.({ forceRefreshToken: false })
+    ).resolves.toBe("session-b-token");
+    expect(token).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
 });

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -17,6 +17,7 @@ import {
 import type { FunctionReference } from "convex/server";
 import type { BetterAuthClientPlugin } from "better-auth";
 import type { createAuthClient } from "better-auth/react";
+import { decodeJwt } from "jose";
 import type {
   convexClient,
   crossDomainClient,
@@ -108,6 +109,17 @@ export function ConvexBetterAuthProvider({
 
 let initialTokenUsed = false;
 
+function getTokenSessionId(token: string): string | null {
+  try {
+    // Convex still verifies the token. Decoding here only determines whether
+    // the cached SSR token belongs to the session that hydrated in the browser.
+    const sessionId = decodeJwt(token).sessionId;
+    return typeof sessionId === "string" && sessionId ? sessionId : null;
+  } catch {
+    return null;
+  }
+}
+
 function useUseAuthFromBetterAuth(
   authClient: AuthClient,
   initialToken?: string | null
@@ -122,6 +134,11 @@ function useUseAuthFromBetterAuth(
           initialTokenUsed ? null : (initialToken ?? null)
         );
         const cachedTokenRef = useRef(cachedToken);
+        // undefined means there is no SSR token awaiting hydration. null means
+        // the token could not be decoded and must not be preserved.
+        const initialTokenSessionIdRef = useRef<string | null | undefined>(
+          cachedToken ? getTokenSessionId(cachedToken) : undefined
+        );
         const tokenGenerationRef = useRef(0);
         const pendingTokenRef = useRef<{
           generation: number;
@@ -130,8 +147,17 @@ function useUseAuthFromBetterAuth(
         } | null>(null);
         const previousSessionIdRef = useRef(sessionId);
         const [sessionVersion, setSessionVersion] = useState(0);
+        const isInitialTokenSessionMismatch =
+          initialTokenSessionIdRef.current !== undefined &&
+          sessionId !== undefined &&
+          initialTokenSessionIdRef.current !== sessionId;
+        const isSessionReplacement =
+          isInitialTokenSessionMismatch ||
+          (previousSessionIdRef.current !== undefined &&
+            previousSessionIdRef.current !== sessionId);
 
         const cacheToken = useCallback((token: string | null) => {
+          initialTokenSessionIdRef.current = undefined;
           cachedTokenRef.current = token;
           setCachedToken(token);
         }, []);
@@ -149,7 +175,10 @@ function useUseAuthFromBetterAuth(
 
         useEffect(() => {
           const previousSessionId = previousSessionIdRef.current;
-          if (previousSessionId && previousSessionId !== sessionId) {
+          if (
+            isInitialTokenSessionMismatch ||
+            (previousSessionId && previousSessionId !== sessionId)
+          ) {
             invalidatePendingToken();
             cacheToken(null);
             if (sessionId) {
@@ -157,7 +186,12 @@ function useUseAuthFromBetterAuth(
             }
           }
           previousSessionIdRef.current = sessionId;
-        }, [cacheToken, invalidatePendingToken, sessionId]);
+        }, [
+          cacheToken,
+          invalidatePendingToken,
+          isInitialTokenSessionMismatch,
+          sessionId,
+        ]);
 
         useEffect(() => {
           if (
@@ -174,6 +208,9 @@ function useUseAuthFromBetterAuth(
           async ({
             forceRefreshToken = false,
           }: { forceRefreshToken?: boolean } = {}) => {
+            if (isSessionReplacement) {
+              return null;
+            }
             if (cachedTokenRef.current && !forceRefreshToken) {
               return cachedTokenRef.current;
             }
@@ -223,15 +260,24 @@ function useUseAuthFromBetterAuth(
           // authClient changes replace this hook factory, and sessionVersion intentionally
           // rebuilds the callback so Convex reauthenticates for a different session.
           // eslint-disable-next-line react-hooks/exhaustive-deps
-          [authClient, cacheToken, sessionVersion]
+          [authClient, cacheToken, isSessionReplacement, sessionVersion]
         );
         return useMemo(
           () => ({
-            isLoading: isSessionPending && !cachedToken,
-            isAuthenticated: Boolean(session?.session) || cachedToken !== null,
+            isLoading:
+              isSessionReplacement || (isSessionPending && !cachedToken),
+            isAuthenticated:
+              !isSessionReplacement &&
+              (Boolean(session?.session) || cachedToken !== null),
             fetchAccessToken,
           }),
-          [isSessionPending, session, fetchAccessToken, cachedToken]
+          [
+            isSessionPending,
+            isSessionReplacement,
+            session,
+            fetchAccessToken,
+            cachedToken,
+          ]
         );
       },
     [authClient, initialToken]

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -122,13 +122,23 @@ function useUseAuthFromBetterAuth(
           initialTokenUsed ? null : (initialToken ?? null)
         );
         const cachedTokenRef = useRef(cachedToken);
-        const pendingTokenRef = useRef<Promise<string | null> | null>(null);
+        const tokenGenerationRef = useRef(0);
+        const pendingTokenRef = useRef<{
+          generation: number;
+          requestId: symbol;
+          promise: Promise<string | null>;
+        } | null>(null);
         const previousSessionIdRef = useRef(sessionId);
         const [sessionVersion, setSessionVersion] = useState(0);
 
         const cacheToken = useCallback((token: string | null) => {
           cachedTokenRef.current = token;
           setCachedToken(token);
+        }, []);
+
+        const invalidatePendingToken = useCallback(() => {
+          tokenGenerationRef.current += 1;
+          pendingTokenRef.current = null;
         }, []);
 
         useEffect(() => {
@@ -139,22 +149,26 @@ function useUseAuthFromBetterAuth(
 
         useEffect(() => {
           const previousSessionId = previousSessionIdRef.current;
-          if (
-            previousSessionId &&
-            sessionId &&
-            previousSessionId !== sessionId
-          ) {
+          if (previousSessionId && previousSessionId !== sessionId) {
+            invalidatePendingToken();
             cacheToken(null);
-            setSessionVersion((version) => version + 1);
+            if (sessionId) {
+              setSessionVersion((version) => version + 1);
+            }
           }
           previousSessionIdRef.current = sessionId;
-        }, [cacheToken, sessionId]);
+        }, [cacheToken, invalidatePendingToken, sessionId]);
 
         useEffect(() => {
-          if (!session && !isSessionPending && cachedTokenRef.current) {
+          if (
+            !session &&
+            !isSessionPending &&
+            (cachedTokenRef.current || pendingTokenRef.current)
+          ) {
+            invalidatePendingToken();
             cacheToken(null);
           }
-        }, [cacheToken, session, isSessionPending]);
+        }, [cacheToken, invalidatePendingToken, session, isSessionPending]);
 
         const fetchAccessToken = useCallback(
           async ({
@@ -163,24 +177,48 @@ function useUseAuthFromBetterAuth(
             if (cachedTokenRef.current && !forceRefreshToken) {
               return cachedTokenRef.current;
             }
-            if (!forceRefreshToken && pendingTokenRef.current) {
-              return pendingTokenRef.current;
+            const pendingToken = pendingTokenRef.current;
+            if (
+              !forceRefreshToken &&
+              pendingToken?.generation === tokenGenerationRef.current
+            ) {
+              return pendingToken.promise;
             }
-            pendingTokenRef.current = authClient.convex
+            const requestGeneration = tokenGenerationRef.current;
+            const requestId = Symbol();
+            const tokenRequest = authClient.convex
               .token({ fetchOptions: { throw: false } })
               .then(({ data }) => {
+                if (
+                  tokenGenerationRef.current !== requestGeneration ||
+                  pendingTokenRef.current?.requestId !== requestId
+                ) {
+                  return null;
+                }
                 const token = data?.token || null;
                 cacheToken(token);
                 return token;
               })
               .catch(() => {
-                cacheToken(null);
+                if (
+                  tokenGenerationRef.current === requestGeneration &&
+                  pendingTokenRef.current?.requestId === requestId
+                ) {
+                  cacheToken(null);
+                }
                 return null;
               })
               .finally(() => {
-                pendingTokenRef.current = null;
+                if (pendingTokenRef.current?.requestId === requestId) {
+                  pendingTokenRef.current = null;
+                }
               });
-            return pendingTokenRef.current;
+            pendingTokenRef.current = {
+              generation: requestGeneration,
+              requestId,
+              promise: tokenRequest,
+            };
+            return tokenRequest;
           },
           // authClient changes replace this hook factory, and sessionVersion intentionally
           // rebuilds the callback so Convex reauthenticates for a different session.

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,5 +1,12 @@
 import type { PropsWithChildren, ReactNode } from "react";
-import { Component, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Component,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { AuthTokenFetcher } from "convex/browser";
 import {
   Authenticated,
@@ -105,33 +112,56 @@ function useUseAuthFromBetterAuth(
   authClient: AuthClient,
   initialToken?: string | null
 ) {
-  const [cachedToken, setCachedToken] = useState<string | null>(
-    initialTokenUsed ? null : (initialToken ?? null)
-  );
-  const pendingTokenRef = useRef<Promise<string | null> | null>(null);
-  useEffect(() => {
-    if (!initialTokenUsed) {
-      initialTokenUsed = true;
-    }
-  }, []);
-
   return useMemo(
     () =>
       function useAuthFromBetterAuth() {
         const { data: session, isPending: isSessionPending } =
           authClient.useSession();
         const sessionId = session?.session?.id;
+        const [cachedToken, setCachedToken] = useState<string | null>(
+          initialTokenUsed ? null : (initialToken ?? null)
+        );
+        const cachedTokenRef = useRef(cachedToken);
+        const pendingTokenRef = useRef<Promise<string | null> | null>(null);
+        const previousSessionIdRef = useRef(sessionId);
+        const [sessionVersion, setSessionVersion] = useState(0);
+
+        const cacheToken = useCallback((token: string | null) => {
+          cachedTokenRef.current = token;
+          setCachedToken(token);
+        }, []);
+
         useEffect(() => {
-          if (!session && !isSessionPending && cachedToken) {
-            setCachedToken(null);
+          if (!initialTokenUsed) {
+            initialTokenUsed = true;
           }
-        }, [session, isSessionPending]);
+        }, []);
+
+        useEffect(() => {
+          const previousSessionId = previousSessionIdRef.current;
+          if (
+            previousSessionId &&
+            sessionId &&
+            previousSessionId !== sessionId
+          ) {
+            cacheToken(null);
+            setSessionVersion((version) => version + 1);
+          }
+          previousSessionIdRef.current = sessionId;
+        }, [cacheToken, sessionId]);
+
+        useEffect(() => {
+          if (!session && !isSessionPending && cachedTokenRef.current) {
+            cacheToken(null);
+          }
+        }, [cacheToken, session, isSessionPending]);
+
         const fetchAccessToken = useCallback(
           async ({
             forceRefreshToken = false,
           }: { forceRefreshToken?: boolean } = {}) => {
-            if (cachedToken && !forceRefreshToken) {
-              return cachedToken;
+            if (cachedTokenRef.current && !forceRefreshToken) {
+              return cachedTokenRef.current;
             }
             if (!forceRefreshToken && pendingTokenRef.current) {
               return pendingTokenRef.current;
@@ -140,11 +170,11 @@ function useUseAuthFromBetterAuth(
               .token({ fetchOptions: { throw: false } })
               .then(({ data }) => {
                 const token = data?.token || null;
-                setCachedToken(token);
+                cacheToken(token);
                 return token;
               })
               .catch(() => {
-                setCachedToken(null);
+                cacheToken(null);
                 return null;
               })
               .finally(() => {
@@ -152,10 +182,10 @@ function useUseAuthFromBetterAuth(
               });
             return pendingTokenRef.current;
           },
-          // Build a new fetchAccessToken to trigger setAuth() whenever the
-          // session changes.
+          // authClient changes replace this hook factory, and sessionVersion intentionally
+          // rebuilds the callback so Convex reauthenticates for a different session.
           // eslint-disable-next-line react-hooks/exhaustive-deps
-          [sessionId]
+          [authClient, cacheToken, sessionVersion]
         );
         return useMemo(
           () => ({
@@ -163,11 +193,10 @@ function useUseAuthFromBetterAuth(
             isAuthenticated: Boolean(session?.session) || cachedToken !== null,
             fetchAccessToken,
           }),
-          // eslint-disable-next-line react-hooks/exhaustive-deps
-          [isSessionPending, sessionId, fetchAccessToken, cachedToken]
+          [isSessionPending, session, fetchAccessToken, cachedToken]
         );
       },
-    [authClient]
+    [authClient, initialToken]
   );
 }
 


### PR DESCRIPTION
## Why this change

Codex identified the behavior described in #398 while diagnosing an authentication hydration issue in my own app, so I thought I would propose the fix upstream rather than keep an app-specific workaround.

In simple terms: when a signed-in page moves from server rendering to the browser, the provider briefly treats the same user as if their authentication changed. That can momentarily clear authentication and make protected queries rerun as logged out, even though the user never signed out. This change keeps authentication stable during that normal handoff, while still resetting it when the user actually changes accounts.

## Summary

- keep `fetchAccessToken` stable when an SSR token hydrates into the same authenticated browser session
- rotate the callback when one authenticated session is replaced by another
- invalidate in-flight token requests when an account changes or signs out so an older token cannot be reused or cached
- read the cached token through a ref so forced refreshes replace the cached value without changing callback identity
- add provider-level regression coverage for hydration, forced refresh, and session replacement

## Root cause

`ConvexBetterAuthProvider` keyed `fetchAccessToken` directly on `sessionId`. During SSR hydration, the session id changes from undefined to the already-authenticated session, so Convex treats the new callback as a new auth context. Its effect cleanup calls `clearAuth()` before `setAuth()`, briefly rerunning subscribed queries without identity.

This change keeps the callback stable for that no-op hydration transition while preserving rotation for a real authenticated-session replacement. The existing cross-domain one-time-token behavior remains unchanged.

Fixes #398.

## Validation

- `npm run build`
- `npm run test` (184 passed, 31 skipped)
- `npm run lint`
- `npm run typecheck`
