### PR TITLE
Add index for rate limit cleanup queries

### DIFF
--- a/src/client/create-schema.test.ts
+++ b/src/client/create-schema.test.ts
@@ -1,0 +1,14 @@
+import { getAuthTables } from "better-auth/db";
+import { describe, expect, it } from "vitest";
+import { options } from "../auth-options.js";
+import { createSchema } from "./create-schema.js";
+
+describe("createSchema", () => {
+  it("generates the index used to clean up expired rate limits", async () => {
+    const { code } = await createSchema({
+      tables: getAuthTables(options),
+    });
+
+    expect(code).toContain('.index("lastRequest", ["lastRequest"])');
+  });
+});

--- a/src/client/create-schema.ts
+++ b/src/client/create-schema.ts
@@ -17,7 +17,7 @@ const resolveCdTarget = (
 // all fields in the schema specialFields are automatically indexed
 export const indexFields = {
   account: ["accountId", ["accountId", "providerId"], ["providerId", "userId"]],
-  rateLimit: ["key"],
+  rateLimit: ["key", "lastRequest"],
   session: ["expiresAt", ["expiresAt", "userId"]],
   verification: ["expiresAt", "identifier"],
   user: [["email", "name"], "name", "userId"],

--- a/src/client/rate-limit-index.test.ts
+++ b/src/client/rate-limit-index.test.ts
@@ -1,0 +1,52 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { makeFunctionReference } from "convex/server";
+import type { FunctionArgs, FunctionReturnType } from "convex/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComponentApi } from "../component/_generated/component.js";
+import schema from "../component/schema.js";
+
+type DeleteMany = ComponentApi["adapter"]["deleteMany"];
+const deleteMany = makeFunctionReference<
+  "mutation",
+  FunctionArgs<DeleteMany>,
+  FunctionReturnType<DeleteMany>
+>("adapter:deleteMany");
+
+describe("rate limit cleanup", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the lastRequest index for range deletion", async () => {
+    const t = convexTest(schema, import.meta.glob("../component/**/*.*s"));
+    await t.run(async (ctx) => {
+      await ctx.db.insert("rateLimit", {
+        key: "expired",
+        count: 1,
+        lastRequest: 100,
+      });
+      await ctx.db.insert("rateLimit", {
+        key: "current",
+        count: 1,
+        lastRequest: 300,
+      });
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await t.mutation(deleteMany, {
+      input: {
+        model: "rateLimit",
+        where: [{ field: "lastRequest", operator: "lt", value: 200 }],
+      },
+      paginationOpts: { cursor: null, numItems: 100 },
+    });
+
+    expect(result.count).toBe(1);
+    expect(warn).not.toHaveBeenCalled();
+    await expect(
+      t.run((ctx) => ctx.db.query("rateLimit").collect())
+    ).resolves.toMatchObject([{ key: "current", lastRequest: 300 }]);
+  });
+});

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -131,7 +131,8 @@ export const tables = {
     count: v.number(),
     lastRequest: v.number(),
   })
-    .index("key", ["key"]),
+    .index("key", ["key"])
+    .index("lastRequest", ["lastRequest"]),
 };
 
 const schema = defineSchema(tables);


### PR DESCRIPTION
Add an index on `rateLimit.lastRequest` so expired rate-limit records can be deleted using an indexed range query.

## Problem

Convex currently reports the following warning during rate-limit cleanup:

```text
[CONVEX M(adapter:deleteMany)] [WARN] Querying without an index on table "rateLimit".
This can cause performance issues, and may hit the document read limit.
To fix, add an index that begins with the following fields in order:
[lastRequest]
```

The cleanup operation filters expired rate-limit records by `lastRequest`, but the `rateLimit` table only has an index on `key`.

## Changes

- Add the `lastRequest` index to the schema generator
- Update the checked-in component schema
- Add regression coverage for generated schemas
- Verify that runtime cleanup deletes expired records without an unindexed-query warning
- Verify that non-expired records are preserved

## Testing

- `npm run build`
- `npm run typecheck`
- `npm run test`
- `npm run lint`

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.