### PR TITLE
fix: cache the JWKS response for a minute

### DIFF
--- a/docs/content/docs/api/convex-plugin.mdx
+++ b/docs/content/docs/api/convex-plugin.mdx
@@ -100,6 +100,30 @@ convex({
 });
 ```
 
+#### `jwksCacheMaxAgeSeconds`
+
+How long the JWKS endpoint response may be cached, in seconds. Defaults to `60`.
+The Convex backend fetches the JWKS url through an http cache while validating a
+token, so a cache lifetime turns one request per validation into one request per
+active cache window. Set it to `0` to send no `Cache-Control` header.
+
+```ts
+convex({
+  authConfig,
+  jwksCacheMaxAgeSeconds: 300,
+});
+```
+
+<Callout>
+  Convex does not refetch the JWKS when it sees an unknown `kid`, so after a key
+  rotation tokens signed with the new key are rejected until the cached set
+  expires, up to `jwksCacheMaxAgeSeconds` seconds. Revocation lags the same way:
+  `rotateKeys` deletes the old key set, while an already cached response still
+  carries the removed public key, so tokens signed with a revoked key keep
+  validating until that cache entry expires. Lower the value or set it to `0` if
+  you rotate keys and cannot tolerate either window.
+</Callout>
+
 #### `options`
 
 Optional Better Auth options, primarily used to pass the `basePath` when using a

--- a/docs/content/docs/experimental.mdx
+++ b/docs/content/docs/experimental.mdx
@@ -91,8 +91,12 @@ then validated using the JWKS.
 
 By default the Better Auth Component uses Convex's
 [`customJwt`](https://docs.convex.dev/auth/advanced/custom-jwt) to avoid the
-OIDC request by providing the JWKS url statically in the auth config. Static
-JWKS avoids both calls by providing the JWKS itself as a data uri.
+OIDC request by providing the JWKS url statically in the auth config, and serves
+that url with a short cache lifetime so the backend fetches it about once per
+cache window rather than once per validation (see
+[`jwksCacheMaxAgeSeconds`](/docs/api/convex-plugin#jwkscachemaxageseconds)).
+Static JWKS avoids both calls entirely by providing the JWKS itself as a data
+uri.
 
 First, add an internal mutation to get the latest JWKS. A new key may be
 written, so this must be a mutation.

--- a/src/plugins/convex/index.test.ts
+++ b/src/plugins/convex/index.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { betterAuth } from "better-auth/minimal";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import type { MemoryDB } from "better-auth/adapters/memory";
 import type { AuthConfig } from "convex/server";
+import { getAuthConfigProvider } from "../../auth-config.js";
 import { convex } from "./index.js";
 
 const authConfig = {
@@ -51,5 +55,108 @@ describe("convex plugin JWT cookie refresh matcher", () => {
     };
     expect(matcher(withSessionCtx as unknown as MatcherContext)).toBe(true);
     expect(matcher(withoutSessionCtx as unknown as MatcherContext)).toBe(false);
+  });
+});
+
+const BASE_URL = "http://localhost:3000";
+const BASE_PATH = "/api/auth";
+
+const createJwksRow = async () => {
+  const { publicKey } = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+  return {
+    id: "test-key-id",
+    alg: "RS256",
+    publicKey: JSON.stringify(await crypto.subtle.exportKey("jwk", publicKey)),
+    createdAt: new Date(),
+  };
+};
+
+const createAuth = async (convexOpts?: { jwksCacheMaxAgeSeconds?: number }) => {
+  const db: MemoryDB = {
+    user: [],
+    session: [],
+    account: [],
+    verification: [],
+    jwks: [await createJwksRow()],
+  };
+  return betterAuth({
+    baseURL: BASE_URL,
+    basePath: BASE_PATH,
+    secret: "test-secret-at-least-thirty-two-characters-long",
+    database: memoryAdapter(db),
+    plugins: [
+      convex({
+        authConfig: { providers: [getAuthConfigProvider()] },
+        ...convexOpts,
+      }),
+    ],
+  });
+};
+
+const getJwks = async (convexOpts?: { jwksCacheMaxAgeSeconds?: number }) => {
+  const auth = await createAuth(convexOpts);
+  return auth.handler(new Request(`${BASE_URL}${BASE_PATH}/convex/jwks`));
+};
+
+describe("convex plugin JWKS cache-control", () => {
+  beforeEach(() => {
+    // The plugin reads CONVEX_SITE_URL when it is constructed.
+    vi.stubEnv("CONVEX_SITE_URL", BASE_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("caches for a minute by default", async () => {
+    const response = await getJwks();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=60, must-revalidate"
+    );
+  });
+
+  it("uses the configured max age", async () => {
+    const response = await getJwks({ jwksCacheMaxAgeSeconds: 300 });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=300, must-revalidate"
+    );
+  });
+
+  it("sends no cache-control header when set to zero", async () => {
+    const response = await getJwks({ jwksCacheMaxAgeSeconds: 0 });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(null);
+  });
+
+  it("does not cache other endpoints", async () => {
+    const auth = await createAuth();
+    const response = await auth.handler(
+      new Request(`${BASE_URL}${BASE_PATH}/ok`)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(null);
+  });
+
+  it("rejects a max age that is not a whole number of seconds", () => {
+    expect(() => convex({ authConfig, jwksCacheMaxAgeSeconds: -1 })).toThrow(
+      /non-negative integer/
+    );
+    expect(() => convex({ authConfig, jwksCacheMaxAgeSeconds: 1.5 })).toThrow(
+      /non-negative integer/
+    );
+    expect(() => convex({ authConfig, jwksCacheMaxAgeSeconds: 1e21 })).toThrow(
+      /non-negative integer/
+    );
   });
 });

--- a/src/plugins/convex/index.ts
+++ b/src/plugins/convex/index.ts
@@ -39,6 +39,20 @@ const getJwksAlg = (authProvider: AuthProvider) => {
   return isCustomJwt ? authProvider.algorithm : "EdDSA";
 };
 
+const DEFAULT_JWKS_CACHE_MAX_AGE_SECONDS = 60;
+
+const parseJwksCacheMaxAgeSeconds = (seconds: number | undefined) => {
+  if (seconds === undefined) {
+    return DEFAULT_JWKS_CACHE_MAX_AGE_SECONDS;
+  }
+  if (!Number.isSafeInteger(seconds) || seconds < 0) {
+    throw new Error(
+      "jwksCacheMaxAgeSeconds must be a non-negative integer number of seconds"
+    );
+  }
+  return seconds;
+};
+
 const parseAuthConfig = (authConfig: AuthConfig, opts: { jwks?: string }) => {
   const providerConfigs = authConfig.providers.filter(
     (provider) => provider.applicationID === "convex"
@@ -158,6 +172,27 @@ export const convex = (opts: {
    */
   jwks?: string;
   /**
+   * @param {number} jwksCacheMaxAgeSeconds - How long the JWKS endpoint response may be cached, in seconds.
+   *
+   * The Convex backend fetches the JWKS url through an http cache while
+   * validating a token. Without a cache lifetime the response is revalidated
+   * on every validation, costing a request and a database read each time.
+   * Set to `0` to send no `Cache-Control` header.
+   *
+   * The trade-off: Convex does not refetch when it sees an unknown `kid`, so
+   * after a key rotation tokens signed with the new key are rejected until the
+   * cached set expires, up to this many seconds. Revocation lags the same way:
+   * `rotateKeys` deletes the old key set, while an already cached response
+   * still carries the removed public key, so tokens signed with a revoked key
+   * keep validating until that cache entry expires. Lowering this value, or
+   * setting `0`, shrinks both windows. Concurrent cache misses are not
+   * coalesced either, so several validations that miss at the same instant
+   * each fetch once.
+   *
+   * @default 60
+   */
+  jwksCacheMaxAgeSeconds?: number;
+  /**
    * @param {boolean} jwksRotateOnTokenGenerationError - Whether to rotate the JWKS on token generation error.
    *
    * Does nothing if a static JWKS is provided.
@@ -174,6 +209,9 @@ export const convex = (opts: {
    */
   options?: BetterAuthOptions;
 }) => {
+  const jwksCacheMaxAgeSeconds = parseJwksCacheMaxAgeSeconds(
+    opts.jwksCacheMaxAgeSeconds
+  );
   const jwtExpirationSeconds =
     opts.jwt?.expirationSeconds ?? opts.jwtExpirationSeconds ?? 60 * 15;
   const oidcProvider = oidcProviderPlugin({
@@ -481,6 +519,12 @@ export const convex = (opts: {
           },
         },
         async (ctx) => {
+          if (jwksCacheMaxAgeSeconds > 0) {
+            ctx.setHeader(
+              "cache-control",
+              `public, max-age=${jwksCacheMaxAgeSeconds}, must-revalidate`
+            );
+          }
           const response = await jwt.endpoints.getJwks({
             ...ctx,
             asResponse: false,


### PR DESCRIPTION
- `GET /convex/jwks` returned no `Cache-Control`. The Convex backend fetches that URL through an http cache on every custom-JWT validation, and a response without freshness is revalidated on every use, so each validated token still cost a round trip plus a `jwks` table read.
- The endpoint now sends `Cache-Control: public, max-age=60, must-revalidate`, one fetch per active minute. In a matched production hour the backend's JWKS fetches dropped from 372 to 50.
- New `jwksCacheMaxAgeSeconds` option (default `60`, non-negative safe integer). `0` sends no header.
- Trade-off, documented in JSDoc and plugin docs: Convex does not refetch on an unknown `kid`, so after a rotation new-key tokens are rejected until the cached set expires, and a revoked key keeps validating for the same window. Static JWKS still avoids the fetch entirely.
- Tests cover the default header, a configured value, the `0` opt-out, untouched endpoints, and rejected values.

Fixes #437
