### PR TITLE
fix: retry jwt-cached Convex calls on auth errors

### DIFF
--- a/docs/content/docs/experimental.mdx
+++ b/docs/content/docs/experimental.mdx
@@ -77,6 +77,11 @@ export const { fetchAuthQuery } = convexBetterAuthReactStart({
 
 </Tabs>
 
+When a Convex call fails with a JWT that came from the cookie rather than a
+fresh fetch, and `isAuthError` returns `true`, the token is refetched and the
+call is retried once. Mutations and actions are retried too, so `isAuthError`
+should only match errors a fresh token can fix.
+
 ## Static JWKS
 
 **Faster page loads, navigation, and client readiness by speeding up Convex

--- a/src/nextjs/index.ts
+++ b/src/nextjs/index.ts
@@ -115,10 +115,11 @@ export const convexBetterAuthNextJs = (
     try {
       return await fn(token?.token);
     } catch (error) {
+      // Refresh only when a cached JWT was rejected as an auth error.
       if (
         !opts?.jwtCache?.enabled ||
         token.isFresh ||
-        opts.jwtCache.isAuthError(error)
+        !opts.jwtCache.isAuthError(error)
       ) {
         throw error;
       }

--- a/src/nextjs/jwt-cache.test.ts
+++ b/src/nextjs/jwt-cache.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FunctionReference } from "convex/server";
+import { convexBetterAuthNextJs } from "./index.js";
+
+const { mockGetToken, mockFetchQuery } = vi.hoisted(() => ({
+  mockGetToken: vi.fn(),
+  mockFetchQuery: vi.fn(),
+}));
+
+vi.mock("../utils/index.js", () => ({
+  getToken: mockGetToken,
+}));
+
+vi.mock("convex/nextjs", () => ({
+  fetchQuery: mockFetchQuery,
+  fetchMutation: vi.fn(),
+  fetchAction: vi.fn(),
+  preloadQuery: vi.fn(),
+}));
+
+vi.mock("next/headers.js", () => ({
+  headers: async () => new Headers({ cookie: "session=abc" }),
+}));
+
+const SITE_URL = "https://test.convex.site";
+const CONVEX_URL = "https://test.convex.cloud";
+const queryRef = {
+  _name: "api.tasks.list",
+} as unknown as FunctionReference<"query">;
+
+const setup = (isAuthError: (error: unknown) => boolean) =>
+  convexBetterAuthNextJs({
+    convexUrl: CONVEX_URL,
+    convexSiteUrl: SITE_URL,
+    jwtCache: {
+      enabled: true,
+      isAuthError,
+    },
+  });
+
+describe("convexBetterAuthNextJs jwtCache retry", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes the token once when the first error is auth-related", async () => {
+    const authError = new Error("Unauthorized");
+    mockGetToken
+      .mockResolvedValueOnce({ token: "stale-token", isFresh: false })
+      .mockResolvedValueOnce({ token: "fresh-token", isFresh: true });
+    mockFetchQuery
+      .mockRejectedValueOnce(authError)
+      .mockResolvedValueOnce([{ text: "ok" }]);
+
+    const { fetchAuthQuery } = setup((error) => error === authError);
+
+    await expect(fetchAuthQuery(queryRef, {})).resolves.toEqual([
+      { text: "ok" },
+    ]);
+
+    expect(mockGetToken).toHaveBeenCalledTimes(2);
+    expect(mockGetToken.mock.calls[1]?.[2]).toMatchObject({
+      forceRefresh: true,
+    });
+    expect(mockFetchQuery).toHaveBeenNthCalledWith(
+      1,
+      queryRef,
+      {},
+      { token: "stale-token" }
+    );
+    expect(mockFetchQuery).toHaveBeenNthCalledWith(
+      2,
+      queryRef,
+      {},
+      { token: "fresh-token" }
+    );
+  });
+
+  it("rethrows non-auth errors without refreshing", async () => {
+    const failure = new Error("validation failed");
+    mockGetToken.mockResolvedValue({ token: "stale-token", isFresh: false });
+    mockFetchQuery.mockRejectedValue(failure);
+
+    const { fetchAuthQuery } = setup(() => false);
+
+    await expect(fetchAuthQuery(queryRef, {})).rejects.toBe(failure);
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(mockFetchQuery).toHaveBeenCalledTimes(1);
+  });
+  it("does not retry when the cached token was already fresh", async () => {
+    const authError = new Error("Unauthorized");
+    mockGetToken.mockResolvedValue({ token: "fresh-token", isFresh: true });
+    mockFetchQuery.mockRejectedValue(authError);
+
+    const { fetchAuthQuery } = setup((error) => error === authError);
+
+    await expect(fetchAuthQuery(queryRef, {})).rejects.toBe(authError);
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(mockFetchQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/react-start/index.ts
+++ b/src/react-start/index.ts
@@ -112,10 +112,11 @@ export const convexBetterAuthReactStart = (
     try {
       return await fn(token?.token);
     } catch (error) {
+      // Refresh only when a cached JWT was rejected as an auth error.
       if (
         !opts?.jwtCache?.enabled ||
         token.isFresh ||
-        opts.jwtCache?.isAuthError(error)
+        !opts.jwtCache?.isAuthError(error)
       ) {
         throw error;
       }

--- a/src/react-start/jwt-cache.test.ts
+++ b/src/react-start/jwt-cache.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FunctionReference } from "convex/server";
+import { convexBetterAuthReactStart } from "./index.js";
+
+const { mockGetToken, mockQuery, mockSetAuth } = vi.hoisted(() => ({
+  mockGetToken: vi.fn(),
+  mockQuery: vi.fn(),
+  mockSetAuth: vi.fn(),
+}));
+
+vi.mock("../utils/index.js", () => ({
+  getToken: mockGetToken,
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    setAuth = mockSetAuth;
+    setFetchOptions() {}
+    query = mockQuery;
+    mutation = vi.fn();
+    action = vi.fn();
+  },
+}));
+
+vi.mock("@tanstack/react-start/server", () => ({
+  getRequestHeaders: () => new Headers({ cookie: "session=abc" }),
+}));
+
+const SITE_URL = "https://test.convex.site";
+const CONVEX_URL = "https://test.convex.cloud";
+const queryRef = {
+  _name: "api.tasks.list",
+} as unknown as FunctionReference<"query">;
+
+const setup = (isAuthError: (error: unknown) => boolean) =>
+  convexBetterAuthReactStart({
+    convexUrl: CONVEX_URL,
+    convexSiteUrl: SITE_URL,
+    jwtCache: {
+      enabled: true,
+      isAuthError,
+    },
+  });
+
+describe("convexBetterAuthReactStart jwtCache retry", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes the token once when the first error is auth-related", async () => {
+    const authError = new Error("Unauthorized");
+    mockGetToken
+      .mockResolvedValueOnce({ token: "stale-token", isFresh: false })
+      .mockResolvedValueOnce({ token: "fresh-token", isFresh: true });
+    mockQuery
+      .mockRejectedValueOnce(authError)
+      .mockResolvedValueOnce([{ text: "ok" }]);
+
+    const { fetchAuthQuery } = setup((error) => error === authError);
+
+    await expect(fetchAuthQuery(queryRef, {})).resolves.toEqual([
+      { text: "ok" },
+    ]);
+
+    expect(mockGetToken).toHaveBeenCalledTimes(2);
+    expect(mockGetToken.mock.calls[1]?.[2]).toMatchObject({
+      forceRefresh: true,
+    });
+    expect(mockSetAuth.mock.calls).toEqual([["stale-token"], ["fresh-token"]]);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows non-auth errors without refreshing", async () => {
+    const failure = new Error("validation failed");
+    mockGetToken.mockResolvedValue({ token: "stale-token", isFresh: false });
+    mockQuery.mockRejectedValue(failure);
+
+    const { fetchAuthQuery } = setup(() => false);
+
+    await expect(fetchAuthQuery(queryRef, {})).rejects.toBe(failure);
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+  it("does not retry when the cached token was already fresh", async () => {
+    const authError = new Error("Unauthorized");
+    mockGetToken.mockResolvedValue({ token: "fresh-token", isFresh: true });
+    mockQuery.mockRejectedValue(authError);
+
+    const { fetchAuthQuery } = setup((error) => error === authError);
+
+    await expect(fetchAuthQuery(queryRef, {})).rejects.toBe(authError);
+    expect(mockGetToken).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

The `catch` in `callWithToken` looks inverted: it rethrows when `isAuthError(error)` is **true**. So a stale cookie JWT that Convex rejects (`Unauthorized`, `Not authenticated`) is never refreshed, while a non-auth error like `"validation failed"` triggers a refetch and retry. Since mutations and actions go through the same path, that retry re-runs them.

The other two clauses already say "only retry a cached, unvalidated token", and staleness shows up as an auth error, so this flips the third clause in the Next.js and TanStack Start helpers.

A bit of history in case it helps: before ed94aca the retry was `if (result.isFresh) throw error;` followed by a refetch, i.e. any error on a cached token. ed94aca introduced `isAuthError` to narrow that, and I think the negation just got lost in the refactor. No test or doc line pinned the polarity. If the current behaviour is intended, happy to close this and keep only the tests and docs.

## Changes

- `nextjs/index.ts`, `react-start/index.ts`: negate the clause, one-line comment.
- `jwt-cache.test.ts` in both: stale + auth error retries once with `forceRefresh` and the new token; non-auth error rethrows; fresh token rethrows.
- `experimental.mdx`: short paragraph on when the retry happens and why `isAuthError` should stay narrow.

## Test plan

- [x] `npx vitest run --typecheck`, `tsc --noEmit`, `npm run lint` all clean
- [x] The retry tests fail on `main` and pass here
