### PR TITLE
fix: usePreloadedAuthQuery returns undefined, not null

### DIFF
--- a/docs/content/docs/framework-guides/next.mdx
+++ b/docs/content/docs/framework-guides/next.mdx
@@ -320,6 +320,10 @@ export const Header = ({
 export default Header;
 ```
 
+Like `useQuery`, `usePreloadedAuthQuery` can return `undefined`: the preloaded
+value is dropped once auth settles as unauthenticated, and there is no live
+result to replace it. Handle it as the snippet above does.
+
 ### Using Better Auth in server code
 
 Better Auth's

--- a/src/nextjs/client.tsx
+++ b/src/nextjs/client.tsx
@@ -8,7 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 const useConvexPreloadedQuery = <Query extends FunctionReference<"query">>(
   preloadedQuery: Preloaded<Query>,
   { requireAuth = true }: { requireAuth?: boolean } = {}
-): Query["_returnType"] => {
+): Query["_returnType"] | undefined => {
   const { isLoading, isAuthenticated } = useConvexAuth();
   const [preloadExpired, setPreloadExpired] = useState(false);
   useEffect(() => {
@@ -41,7 +41,9 @@ const useConvexPreloadedQuery = <Query extends FunctionReference<"query">>(
 
 export const usePreloadedAuthQuery = <Query extends FunctionReference<"query">>(
   preloadedQuery: Preloaded<Query>
-): Query["_returnType"] | null => {
+  // `undefined` once the preloaded value expires with no live result to
+  // replace it, eg. when auth settles as unauthenticated. Same as `useQuery`.
+): Query["_returnType"] | undefined => {
   const { isLoading } = useConvexAuth();
   const latestData = useConvexPreloadedQuery(preloadedQuery);
   const [data, setData] = useState(latestData);

--- a/src/nextjs/client.types.test.ts
+++ b/src/nextjs/client.types.test.ts
@@ -1,0 +1,17 @@
+import type { FunctionReference } from "convex/server";
+import { expectTypeOf, it } from "vitest";
+import type { usePreloadedAuthQuery } from "./client.js";
+
+type Todo = { _id: string; text: string };
+type TodosQuery = FunctionReference<
+  "query",
+  "public",
+  Record<string, never>,
+  Todo[]
+>;
+
+it("returns the query result or undefined, like useQuery", () => {
+  expectTypeOf<
+    ReturnType<typeof usePreloadedAuthQuery<TodosQuery>>
+  >().toEqualTypeOf<Todo[] | undefined>();
+});


### PR DESCRIPTION
## Summary

`usePreloadedAuthQuery` is declared as `Query["_returnType"] | null`, but what it actually returns is `Query["_returnType"] | undefined`.

`undefined` shows up once the preloaded value expires with no live result to replace it, e.g. auth settles as unauthenticated so the query is skipped. `null` never comes from the hook itself; if a query returns `null`, `Query["_returnType"]` already covers it. The `examples/next` components already `?.` the result, which is a hint the type has been off for a while.

This aligns the declaration with `useQuery`, which is the shape most people will expect anyway.

Small heads-up: anyone who annotated the result as `| null` will get a type error. That check was unreachable, so the error points at a real gap, but I'm happy to widen to `| null | undefined` instead if you'd rather keep it non-breaking.

## Changes

- `src/nextjs/client.tsx`: `| undefined` on both the internal and exported hook, with a short comment
- `src/nextjs/client.types.test.ts`: pins the return type (fails on `main` under `tsc --noEmit`)
- `docs/.../next.mdx`: one line noting the hook can return `undefined`, like `useQuery`

## Test plan

- [x] `npx vitest run --typecheck`, `tsc --noEmit`, `npm run lint` all clean
